### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,15 +41,9 @@ find_package(DD4hep)
 
 #---------------------------------------------------------------
 
+include(cmake/Key4hepConfig.cmake)
+
 include(GNUInstallDirs)
-
-# Set up C++ Standard
-# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
-if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
 
 include(CTest)
 


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/359.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

ENDRELEASENOTES