### PR TITLE
Make sure to find DD4hep first to avoid python issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,12 @@ list(APPEND CMAKE_MODULE_PATH $ENV{PANDORAPFA}/cmakemodules)
 
 # dependencies are declared like this
 find_package(ROOT COMPONENTS RIO Tree)
+find_package(DD4hep)
 find_package(EDM4HEP)
 find_package(k4FWCore)
 find_package(PandoraSDK)
 find_package(LCContent)
 find_package(Gaudi)
-find_package(DD4hep)
 
 #---------------------------------------------------------------
 


### PR DESCRIPTION
DD4hep has to be found pretty much first for CMake because it is the one that requires an exact version of python. However, if anything else (e.g. Boost via Gaudi) finds another version of python (typically a newer one from the underlying system) then this version will be cached and the check in the DD4hep cmake configuration will fail.

Just ran into this on Ubuntu 24, where the system python is 3.12


BEGINRELEASENOTES
- Make sure to find DD4hep first in CMake config to avoid finding conflicting versions of python.

ENDRELEASENOTES
