### PR TITLE
replace removed `IOSvc` properties `input` and `output`

### DIFF
--- a/k4GaudiPandora/options/createExampleEventData.py
+++ b/k4GaudiPandora/options/createExampleEventData.py
@@ -22,7 +22,7 @@ from k4FWCore import ApplicationMgr
 from k4FWCore import IOSvc
 
 iosvc = IOSvc("IOSvc")
-iosvc.output = "output_k4test_exampledata.root"
+iosvc.Output = "output_k4test_exampledata.root"
 iosvc.outputCommands = ["keep *"]
 
 producer = CreateExampleEventData()

--- a/k4GaudiPandora/options/runDDSimpleMuonDigi.py
+++ b/k4GaudiPandora/options/runDDSimpleMuonDigi.py
@@ -53,8 +53,8 @@ digi.detectornameB = "YokeBarrel"
 digi.detectornameE = "YokeEndcap"
 
 iosvc = IOSvc()
-iosvc.input = "../simulation/sim_partgun_1000.root"
-iosvc.output = "../outputfiles/output_Gaudi.root"
+iosvc.Input = "../simulation/sim_partgun_1000.root"
+iosvc.Output = "../outputfiles/output_Gaudi.root"
 
 hps = RootHistSvc("HistogramPersistencySvc")
 root_hist_svc = RootHistoSink("RootHistoSink")


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the properties `Input` and `Output` with `IOSvc` instead of the deprecated `input` and `output`.

ENDRELEASENOTES

The  `IOSvc` properties `input` and `output` were deprecated and removed in key4hep/k4FWCore#297.