### PR TITLE
Add LANGUAGES CXX to the project call to disable checking for a C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ limitations under the License.
 CMAKE_MINIMUM_REQUIRED(VERSION 3.19)
 
 
-project(k4GaudiPandora)
+project(k4GaudiPandora LANGUAGES CXX)
 
 # please keep this layout for version setting, used by the automatic tagging script
 set(PACKAGE_VERSION_MAJOR 1)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LANGUAGES CXX to the project call to disable checking for a C compiler

ENDRELEASENOTES