### PR TITLE
Fix defaults in DDSimpleMuonDigi

### DIFF
--- a/k4GaudiPandora/include/DDSimpleMuonDigi.h
+++ b/k4GaudiPandora/include/DDSimpleMuonDigi.h
@@ -50,16 +50,16 @@ struct DDSimpleMuonDigi final
 private:
   Gaudi::Property<std::string> m_subDetName{this, "SubDetectorName", "VXD", "Name of the subdetector"};
   Gaudi::Property<std::vector<size_t>> m_layersToKeepBarrelVec{
-      this, "KeepBarrelLayersVec", {0}, "Vector of Barrel layers to be kept. Layers start at 1!"};
+      this, "KeepBarrelLayersVec", {}, "Vector of Barrel layers to be kept. Layers start at 1!"};
   Gaudi::Property<std::vector<size_t>> m_layersToKeepEndCapVec{
-      this, "KeepEndcapLayersVec", {0}, "Vector of Endcap layers to be kept. Layers start at 1!"};
+      this, "KeepEndcapLayersVec", {}, "Vector of Endcap layers to be kept. Layers start at 1!"};
   // Gaudi::Property<std::vector<bool>> useLayersBarrelVec{this, "useBarrelLayerVector", false, "whether to use the
   // endcap layer vector"}; Gaudi::Property<std::vector<bool>> useLayersEndcapVec{this, "useEndCapLayerVector", false,
   // "whether to use the EndCap layer vector"};
   Gaudi::Property<std::string> m_cellIDLayerString{this, "CellIDLayerString", "layer",
                                                    "Name of the part of the cellID that holds the layer"};
-  Gaudi::Property<float> m_thresholdMuon{this, "MuonThreshold", {0.025}, "Threshold for muon"};
-  Gaudi::Property<float> m_timeThresholdMuon{this, "timethresholdMuon", {0.025}, "time threshold for muons"};
+  Gaudi::Property<float> m_thresholdMuon{this, "MuonThreshold", {0.025f}, "Threshold for muon"};
+  Gaudi::Property<float> m_timeThresholdMuon{this, "timethresholdMuon", {0.025f}, "time threshold for muons"};
   Gaudi::Property<float> m_calibrCoeffMuon{this, "CalibrMUON", {120000.0}, "Callibration coefficient of muons"};
   Gaudi::Property<float> m_maxHitEnergyMuon{this, "MaxHitEnergyMUON", {2.0}, "Threshold for maximum muon hit energy"};
   Gaudi::Property<std::string> m_detectorNameBarrel{this, "detectornameB", "YokeBarrel", "Name of the subdetector"};

--- a/k4GaudiPandora/options/runDDSimpleMuonDigi.py
+++ b/k4GaudiPandora/options/runDDSimpleMuonDigi.py
@@ -55,7 +55,7 @@ for alg, inputcol, outputcol, outrel in zip(
 
     alg.MUONCollection = [inputcol]
     alg.RelationOutputCollection = [outrel]
-    alg.MUONOutputCollections = [outputcol]
+    alg.MUONOutputCollection = [outputcol]
 
     alg.CellIDLayerString = "layer"
 

--- a/k4GaudiPandora/src/DDSimpleMuonDigi.cc
+++ b/k4GaudiPandora/src/DDSimpleMuonDigi.cc
@@ -41,7 +41,7 @@ DDSimpleMuonDigi::DDSimpleMuonDigi(const std::string& aName, ISvcLocator* aSvcLo
                            KeyValues("MUONCollection", {"ECalBarrelCollection"}),
                            KeyValues("HeaderName", {"EventHeader"}),
                        },
-                       {KeyValues("MUONOutputCollections", {"CalorimeterHit"}),
+                       {KeyValues("MUONOutputCollection", {"CalorimeterHit"}),
                         KeyValues("RelationOutputCollection", {"RelationMuonHit"})}) {}
 
 StatusCode DDSimpleMuonDigi::initialize() {


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix defaults in DDSimpleMuonDigi, set layers to keep to be an empty vector by default to fix a crash when the default value is used. Change the name of the output collection to be in singular `MUONOutputCollection` instead of `MUONOutputCollections`.

ENDRELEASENOTES