### PR TITLE
Use the inputLocations function instead of the member

### DIFF
--- a/k4GaudiPandora/src/DDCaloDigi.cc
+++ b/k4GaudiPandora/src/DDCaloDigi.cc
@@ -262,7 +262,7 @@ retType DDCaloDigi::operator()(const edm4hep::SimCalorimeterHitCollection& simCa
   const double event_correl_miscalib_ecal = CLHEP::RandGauss::shoot(&randomEngine, 1.0, m_misCalibEcal_correl.value());
   const double event_correl_miscalib_hcal = CLHEP::RandGauss::shoot(&randomEngine, 1.0, m_misCalibHcal_correl.value());
 
-  const std::string colName = m_inputLocations[0][0].key();  // take input collection name
+  const std::string colName = inputLocations(0)[0];  // take input collection name
   debug() << "looking for collection: " << colName << std::endl;
 
   if (colName.find("dummy") != std::string::npos) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the `inputLocations` function in `DDCaloDigi` instead of the member since the member may be removed in a coming pull request (https://github.com/key4hep/k4FWCore/pull/345) and it's a detail of the implementation.

ENDRELEASENOTES

This was probably done because at that time the function didn't exist. Maybe one day the members are private.