### PR TITLE
Enable external clustering algorithm

### DIFF
--- a/cmake/Key4hepConfig.cmake
+++ b/cmake/Key4hepConfig.cmake
@@ -43,7 +43,7 @@ endmacro()
 macro(key4hep_set_cxx_standard_and_extensions)
   set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
-  if(NOT CMAKE_CXX_STANDARD MATCHES "20|23")
+  if(NOT CMAKE_CXX_STANDARD MATCHES "20|23|26")
     message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}, supported values are 20 and 23")
   endif()
 

--- a/k4GaudiPandora/CMakeLists.txt
+++ b/k4GaudiPandora/CMakeLists.txt
@@ -24,7 +24,7 @@ set(_plugin_sources ${CMAKE_CURRENT_LIST_DIR}/
                     src/DDScintillatorPpdDigi.cc
                     src/DDBFieldPlugin.cc
                     src/DDCaloHitCreator.cc
-                    # src/DDExternalClusteringAlgorithm.cc
+                    src/DDExternalClusteringAlgorithm.cc
                     src/DDGeometryCreator.cc
                     src/DDMCParticleCreator.cc
                     src/DDPfoCreator.cc

--- a/k4GaudiPandora/include/DDCaloDigi.h
+++ b/k4GaudiPandora/include/DDCaloDigi.h
@@ -95,35 +95,6 @@
  *  @version $Id$ <br>
  */
 
-#include "GAUDI_VERSION.h"
-
-#if GAUDI_MAJOR_VERSION < 39
-namespace Gaudi::Accumulators {
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
-using StaticHistogram = Gaudi::Accumulators::HistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString,
-                                                                     HistogramingAccumulator>;
-
-/// helper class to create a tuple of N identical types
-template <typename T, unsigned int ND, typename = std::make_integer_sequence<unsigned int, ND>>
-struct make_tuple;
-template <typename T, unsigned int ND, unsigned int... S>
-struct make_tuple<T, ND, std::integer_sequence<unsigned int, S...>> {
-  template <unsigned int>
-  using typeMap = T;
-  using type = std::tuple<typeMap<S>...>;
-};
-template <typename T, unsigned int ND>
-using make_tuple_t = typename make_tuple<T, ND>::type;
-
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double,
-          typename AxisTupleType = make_tuple_t<Axis<Arithmetic>, ND>>
-using StaticWeightedHistogram = HistogramingCounterBase<ND, Atomicity, Arithmetic, naming::weightedHistogramString,
-                                                        WeightedHistogramingAccumulator>;
-
-} // namespace Gaudi::Accumulators
-
-#endif
-
 const int MAX_LAYERS = 200;
 const int MAX_STAVES = 16;
 

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -44,6 +44,21 @@ namespace pandora {
 class CaloHit;
 }
 
+/**
+ *  @brief  ExternalClusterHolder class - holds pointers to the external clusters and the calo hits
+ */
+
+class ExternalClusterHolder {
+public:
+  ExternalClusterHolder() = default;
+  ~ExternalClusterHolder() = default;
+
+  void setExternalClusters(std::vector<std::vector<edm4hep::Cluster>>* externalClusters);
+  const std::vector<std::vector<edm4hep::Cluster>> getExternalClusters() const;
+
+  std::vector<std::vector<edm4hep::Cluster>>* m_externalClusters; ///< The external clusters
+};
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -51,7 +66,7 @@ class CaloHit;
  */
 class ExternalEventParameter : public pandora::ExternalParameters {
 public:
-  IDataProviderSvc* m_pEventService; ///< Pointer to Gaudi event service
+  ExternalClusterHolder* m_externalClusterHolder; ///< Pointer to external cluster holder
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -80,11 +95,9 @@ private:
 
   typedef std::unordered_map<podio::ObjectID, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
 
-  std::vector<std::string> m_externalClusterCollectionNames = {}; // list of external cluster collection names
   bool m_flagClustersAsPhotons = true; ///< Whether to automatically flag new clusters as fixed photons
 
-  IDataProviderSvc* m_pEventService = nullptr; // persistent pointer to Gaudi event service
-                                               // (owned by the DDPandoraPFANewAlgorithm)
+  ExternalClusterHolder* m_externalClusterHolder = nullptr; ///< Pointer to external cluster holder
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -32,6 +32,9 @@
 #include "Objects/CaloHit.h"
 #include "Pandora/ExternallyConfiguredAlgorithm.h"
 
+// Podio
+#include "podio/ObjectID.h"
+
 // c++
 #include <map>
 
@@ -75,7 +78,7 @@ private:
   pandora::StatusCode Run();
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-  typedef std::map<uint64_t, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
+  typedef std::unordered_map<podio::ObjectID, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
 
   std::vector<std::string> m_externalClusterCollectionNames = {}; // list of external cluster collection names
   bool m_flagClustersAsPhotons = true; ///< Whether to automatically flag new clusters as fixed photons

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -54,7 +54,7 @@ public:
   ~ExternalClusterHolder() = default;
 
   void setExternalClusters(std::vector<std::vector<edm4hep::Cluster>>* externalClusters);
-  const std::vector<std::vector<edm4hep::Cluster>> getExternalClusters() const;
+  const std::vector<std::vector<edm4hep::Cluster>>& getExternalClusters() const;
 
   std::vector<std::vector<edm4hep::Cluster>>* m_externalClusters; ///< The external clusters
 };

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -28,9 +28,9 @@
 #define DDEXTERNALCLUSTERINGALGORITHM_H 1
 
 // Pandora
-#include "Pandora/ExternallyConfiguredAlgorithm.h"
 #include "Helpers/XmlHelper.h"
 #include "Objects/CaloHit.h"
+#include "Pandora/ExternallyConfiguredAlgorithm.h"
 
 // c++
 #include <map>
@@ -78,7 +78,7 @@ private:
   typedef std::map<uint64_t, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
 
   std::vector<std::string> m_externalClusterCollectionNames = {}; // list of external cluster collection names
-  bool m_flagClustersAsPhotons = true;              ///< Whether to automatically flag new clusters as fixed photons
+  bool m_flagClustersAsPhotons = true; ///< Whether to automatically flag new clusters as fixed photons
 
   IDataProviderSvc* m_pEventService = nullptr; // persistent pointer to Gaudi event service
                                                // (owned by the DDPandoraPFANewAlgorithm)

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -27,9 +27,15 @@
 #ifndef DDEXTERNALCLUSTERINGALGORITHM_H
 #define DDEXTERNALCLUSTERINGALGORITHM_H 1
 
-#include "Pandora/Algorithm.h"
+// Pandora
+#include "Pandora/ExternallyConfiguredAlgorithm.h"
+#include "Helpers/XmlHelper.h"
+#include "Objects/CaloHit.h"
 
+// c++
 #include <map>
+
+class IDataProviderSvc;
 
 namespace pandora {
 class CaloHit;
@@ -38,9 +44,19 @@ class CaloHit;
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
+ *  @brief  ExternalEventParameter class - holds Gaudi event service for external clustering
+ */
+class ExternalEventParameter : public pandora::ExternalParameters {
+public:
+  IDataProviderSvc* m_pEventService; ///< Pointer to Gaudi event service
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
  *  @brief  DDExternalClusteringAlgorithm class
  */
-class DDExternalClusteringAlgorithm : public pandora::Algorithm {
+class DDExternalClusteringAlgorithm : public pandora::ExternallyConfiguredAlgorithm {
 public:
   /**
    *  @brief  Factory class for instantiating algorithm
@@ -59,9 +75,9 @@ private:
   pandora::StatusCode Run();
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-  typedef std::map<const void*, const pandora::CaloHit*> ParentAddressToCaloHitMap;
+  typedef std::map<uint64_t, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
 
-  std::string m_externalClusterCollectionName = ""; ///< The collection name for the external clusters
+  std::vector<std::string> m_externalClusterCollectionNames = {}; // list of external cluster collection names
   bool m_flagClustersAsPhotons = true;              ///< Whether to automatically flag new clusters as fixed photons
 };
 

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -79,6 +79,9 @@ private:
 
   std::vector<std::string> m_externalClusterCollectionNames = {}; // list of external cluster collection names
   bool m_flagClustersAsPhotons = true;              ///< Whether to automatically flag new clusters as fixed photons
+
+  IDataProviderSvc* m_pEventService = nullptr; // persistent pointer to Gaudi event service
+                                               // (owned by the DDPandoraPFANewAlgorithm)
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -42,8 +42,6 @@
 #include <vector>
 #include <unordered_map>
 
-class IDataProviderSvc;
-
 namespace pandora {
 class CaloHit;
 }

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -37,6 +37,8 @@
 
 // c++
 #include <map>
+#include <vector>
+#include <unordered_map>
 
 class IDataProviderSvc;
 

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -35,6 +35,8 @@
 // Podio
 #include "podio/ObjectID.h"
 
+#include "edm4hep/Cluster.h"
+
 // c++
 #include <map>
 #include <vector>

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -39,8 +39,8 @@
 
 // c++
 #include <map>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace pandora {
 class CaloHit;

--- a/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
+++ b/k4GaudiPandora/include/DDExternalClusteringAlgorithm.h
@@ -97,7 +97,7 @@ private:
 
   typedef std::unordered_map<podio::ObjectID, const pandora::CaloHit*> ExternalToPandoraCaloHitMap;
 
-  bool m_flagClustersAsPhotons = true; ///< Whether to automatically flag new clusters as fixed photons
+  bool m_flagClustersAsPhotons = false; ///< Whether to automatically flag new clusters as fixed photons
 
   ExternalClusterHolder* m_externalClusterHolder = nullptr; ///< Pointer to external cluster holder
 };

--- a/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
+++ b/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
@@ -46,6 +46,9 @@ namespace pandora {
 class Pandora;
 }
 
+class IDataProviderSvc;
+class ExternalEventParameter;
+
 dd4hep::rec::LayeredCalorimeterData* getExtension(unsigned int includeFlag, unsigned int excludeFlag = 0);
 
 struct DDPandoraPFANewAlgorithm final
@@ -165,6 +168,8 @@ private:
   std::unique_ptr<DDMCParticleCreator> m_pDDMCParticleCreator; ///< The mc particle creator
   std::unique_ptr<DDPfoCreator> m_pfoCreator;                  ///< The pfo creator
   SmartIF<IGeoSvc> m_geoSvc;                                   ///< The GeoSvc
+  SmartIF<IDataProviderSvc> m_dataSvc;                         ///< DataProviderSvc for external clustering
+  std::unique_ptr<ExternalEventParameter> m_extEvtParam;       ///< external event parameter
 
   Settings m_settings{};                                       ///< The settings for the pandora pfa new processor
   DDCaloHitCreator::Settings m_caloHitCreatorSettings{};       ///< The calo hit creator settings

--- a/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
+++ b/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
@@ -46,8 +46,9 @@ namespace pandora {
 class Pandora;
 }
 
-class IDataProviderSvc;
+// forward declarations for the external clustering algorithm
 class ExternalEventParameter;
+class ExternalClusterHolder;
 
 dd4hep::rec::LayeredCalorimeterData* getExtension(unsigned int includeFlag, unsigned int excludeFlag = 0);
 
@@ -64,7 +65,8 @@ struct DDPandoraPFANewAlgorithm final
           const std::vector<const edm4hep::CalorimeterHitCollection*>&,
           const std::vector<const edm4hep::CalorimeterHitCollection*>&,
           const std::vector<const edm4hep::CalorimeterHitCollection*>&,
-          const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&)> {
+          const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&,
+          const std::vector<const edm4hep::ClusterCollection*>&)> {
 public:
   class Settings {
   public:
@@ -140,7 +142,8 @@ public:
              const std::vector<const edm4hep::CalorimeterHitCollection*>& mCalCollections,
              const std::vector<const edm4hep::CalorimeterHitCollection*>& lCalCollections,
              const std::vector<const edm4hep::CalorimeterHitCollection*>& lhCalCollections,
-             const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>& caloLinkCollections) const override;
+             const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>& caloLinkCollections,
+             const std::vector<const edm4hep::ClusterCollection*>& clusterCollections) const override;
 
   const pandora::Pandora* GetPandora() const;
 
@@ -168,8 +171,8 @@ private:
   std::unique_ptr<DDMCParticleCreator> m_pDDMCParticleCreator; ///< The mc particle creator
   std::unique_ptr<DDPfoCreator> m_pfoCreator;                  ///< The pfo creator
   SmartIF<IGeoSvc> m_geoSvc;                                   ///< The GeoSvc
-  SmartIF<IDataProviderSvc> m_dataSvc;                         ///< DataProviderSvc for external clustering
   std::unique_ptr<ExternalEventParameter> m_extEvtParam;       ///< external event parameter
+  std::unique_ptr<ExternalClusterHolder> m_extClusterHolder;   ///< Pointer to external cluster holder
 
   Settings m_settings{};                                       ///< The settings for the pandora pfa new processor
   DDCaloHitCreator::Settings m_caloHitCreatorSettings{};       ///< The calo hit creator settings

--- a/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
+++ b/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
@@ -171,8 +171,9 @@ private:
   std::unique_ptr<DDMCParticleCreator> m_pDDMCParticleCreator; ///< The mc particle creator
   std::unique_ptr<DDPfoCreator> m_pfoCreator;                  ///< The pfo creator
   SmartIF<IGeoSvc> m_geoSvc;                                   ///< The GeoSvc
-  std::unique_ptr<ExternalEventParameter> m_extEvtParam;       ///< external event parameter
-  std::unique_ptr<ExternalClusterHolder> m_extClusterHolder;   ///< Pointer to external cluster holder
+  ExternalEventParameter* m_extEvtParam;                     ///< external event parameter (pandora::ExternalParameters)
+                                                             ///< created by this algo but deleted by Pandora
+  std::unique_ptr<ExternalClusterHolder> m_extClusterHolder; ///< Pointer to external cluster holder
 
   Settings m_settings{};                                       ///< The settings for the pandora pfa new processor
   DDCaloHitCreator::Settings m_caloHitCreatorSettings{};       ///< The calo hit creator settings

--- a/k4GaudiPandora/options/PandoraSettingsExternalClustering.xml
+++ b/k4GaudiPandora/options/PandoraSettingsExternalClustering.xml
@@ -1,0 +1,29 @@
+<!--
+-- Copyright (c) 2020-2024 Key4hep-Project.
+--
+-- This file is part of Key4hep.
+-- See https://key4hep.github.io/key4hep-doc/ for further info.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+  -->
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>true</ShouldDisplayAlgorithmInfo>
+    <ShouldCollapseMCParticlesToPfoTarget>false</ShouldCollapseMCParticlesToPfoTarget>
+
+    <algorithm type = "DDExternalClustering">
+        <FlagClustersAsPhotons>false</FlagClustersAsPhotons>
+        <ExternalClusterCollectionNames>PandoraClusters</ExternalClusterCollectionNames>
+    </algorithm>
+</pandora>

--- a/k4GaudiPandora/options/PandoraSettingsExternalClustering.xml
+++ b/k4GaudiPandora/options/PandoraSettingsExternalClustering.xml
@@ -24,6 +24,5 @@
 
     <algorithm type = "DDExternalClustering">
         <FlagClustersAsPhotons>false</FlagClustersAsPhotons>
-        <ExternalClusterCollectionNames>PandoraClusters</ExternalClusterCollectionNames>
     </algorithm>
 </pandora>

--- a/k4GaudiPandora/options/runExternalClustering.py
+++ b/k4GaudiPandora/options/runExternalClustering.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2020-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from Gaudi.Configuration import INFO
+from k4FWCore import ApplicationMgr, IOSvc
+from Configurables import EventDataSvc
+from Configurables import DDPandoraPFANewAlgorithm
+
+import os
+
+iosvc = IOSvc()
+iosvc.Input = "output_pandora_ttbar.root"
+iosvc.Output = "output_externalClustering.root"
+
+import sys
+
+# Get the absolute path of the directory where this script resides
+# to avoid redefining the pandora input parameters
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(current_dir)
+
+# now import pandora params
+from runPandora import params
+
+# dummy Pandora settings file containing only external clustering algo
+params["PandoraSettingsXmlFile"] = current_dir+"/PandoraSettingsExternalClustering.xml"
+# rename output collection names to avoid conflicts
+params["ClusterCollectionName"] = ["GaudiExternalClusters"]
+params["PFOCollectionName"] = ["GaudiExternalClusteringPandoraPFOs"]
+params["StartVertexCollectionName"] = ["GaudiExternalClusteringPandoraStartVertices"]
+
+pandora = DDPandoraPFANewAlgorithm("PandoraPFANewAlgorithm", **params)
+
+ApplicationMgr(
+    TopAlg=[pandora],
+    EvtSel="NONE",
+    EvtMax=-1,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/k4GaudiPandora/options/runExternalClustering.py
+++ b/k4GaudiPandora/options/runExternalClustering.py
@@ -40,6 +40,7 @@ from runPandora import params
 # dummy Pandora settings file containing only external clustering algo
 params["PandoraSettingsXmlFile"] = current_dir+"/PandoraSettingsExternalClustering.xml"
 # rename output collection names to avoid conflicts
+params["ClusterCollections"] = ["PandoraClusters"]
 params["ClusterCollectionName"] = ["GaudiExternalClusters"]
 params["PFOCollectionName"] = ["GaudiExternalClusteringPandoraPFOs"]
 params["StartVertexCollectionName"] = ["GaudiExternalClusteringPandoraStartVertices"]

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -60,17 +60,6 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
       caloHitMap.emplace(edmCaloHit->getCellID(), pCaloHit);
     }
 
-    // Get current Gaudi event to retrieve external clusters
-    // Retrieve the Gaudi event service from external parameters set by the parent algorithm
-    const ExternalEventParameter* pExternalEventParameter =
-        dynamic_cast<const ExternalEventParameter*>(this->GetExternalParameters());
-
-    if (!pExternalEventParameter || !pExternalEventParameter->m_pEventService) {
-      throw std::runtime_error("DDExternalClusteringAlgorithm: External event parameter not set");
-    }
-
-    auto* gaudiEvent = pExternalEventParameter->m_pEventService;
-
     // Recreate external clusters within the pandora framework
     const pandora::ClusterList* pClusterList = nullptr;
 
@@ -84,7 +73,7 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
     // loop over external cluster collections
     for (const auto& colName : m_externalClusterCollectionNames) {
       DataObject* rawObj = nullptr;
-      StatusCode sc = gaudiEvent->retrieveObject("/Event/" + colName, rawObj);
+      StatusCode sc = m_pEventService->retrieveObject("/Event/" + colName, rawObj);
 
       if (sc.isFailure() || rawObj == nullptr) {
         throw std::runtime_error("DDExternalClusteringAlgorithm: Cannot retrieve the external cluster collection " + colName);
@@ -172,6 +161,19 @@ pandora::StatusCode DDExternalClusteringAlgorithm::ReadSettings(const pandora::T
   PANDORA_RETURN_RESULT_IF_AND_IF(
       pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
       pandora::XmlHelper::ReadValue(xmlHandle, "FlagClustersAsPhotons", m_flagClustersAsPhotons));
+
+  // Get current Gaudi event to retrieve external clusters
+  // Retrieve the Gaudi event service from external parameters set by the parent algorithm
+  // Sanghyun: this is a hacky way that I do this in ReadSettings
+  // but GetExternalParameters doesn't allow me to access it more that once
+  const ExternalEventParameter* pExternalEventParameter =
+      dynamic_cast<const ExternalEventParameter*>(this->GetExternalParameters());
+
+  if (!pExternalEventParameter || !pExternalEventParameter->m_pEventService) {
+    throw std::runtime_error("DDExternalClusteringAlgorithm: External event parameter not set");
+  }
+
+  m_pEventService = pExternalEventParameter->m_pEventService;
 
   return pandora::STATUS_CODE_SUCCESS;
 }

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -35,6 +35,15 @@
 #include "GaudiKernel/AnyDataWrapper.h"
 #include "GaudiKernel/IDataProviderSvc.h"
 
+// setters and getters for the external cluster holder
+void ExternalClusterHolder::setExternalClusters(std::vector<std::vector<edm4hep::Cluster>>* externalClusters) {
+  m_externalClusters = externalClusters;
+}
+
+const std::vector<std::vector<edm4hep::Cluster>> ExternalClusterHolder::getExternalClusters() const {
+  return *m_externalClusters;
+}
+
 DDExternalClusteringAlgorithm::DDExternalClusteringAlgorithm() : m_flagClustersAsPhotons(false) {}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -69,35 +78,12 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
         PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListNameTmp));
 
     // loop over external cluster collections
-    for (const auto& colName : m_externalClusterCollectionNames) {
-      DataObject* rawObj = nullptr;
-      StatusCode sc = m_pEventService->retrieveObject("/Event/" + colName, rawObj);
-
-      if (sc.isFailure() || rawObj == nullptr) {
-        throw std::runtime_error("DDExternalClusteringAlgorithm: Cannot retrieve the external cluster collection " +
-                                 colName);
-      }
-
-      auto anyWrapper = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(rawObj);
-
-      if (!anyWrapper) {
-        throw std::runtime_error("DDExternalClusteringAlgorithm: Failed to cast to AnyDataWrapper");
-      }
-
-      // get the underlying cluster collection
-      auto collBasePtr = anyWrapper->getData().get();
-      auto pExternalClusterCollection = dynamic_cast<const edm4hep::ClusterCollection*>(collBasePtr);
-
-      if (!pExternalClusterCollection) {
-        throw std::runtime_error("DDExternalClusteringAlgorithm: Failed to cast CollectionBase to ClusterCollection");
-      }
-
+    for (const auto& clusterColl : m_externalClusterHolder->getExternalClusters()) {
       // no cluster in this event
-      if (0 == pExternalClusterCollection->size())
+      if (clusterColl.empty())
         continue;
 
-      // loop over external clusters
-      for (const edm4hep::Cluster& externalCluster : *pExternalClusterCollection) {
+      for (const auto& externalCluster : clusterColl) {
         const auto& calorimeterHitVec = externalCluster.getHits();
         pandora::CaloHitList pandoraHitList;
 
@@ -152,26 +138,21 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 pandora::StatusCode DDExternalClusteringAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                           pandora::XmlHelper::ReadVectorOfValues(xmlHandle, "ExternalClusterCollectionNames",
-                                                                  m_externalClusterCollectionNames));
-
   PANDORA_RETURN_RESULT_IF_AND_IF(
       pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
       pandora::XmlHelper::ReadValue(xmlHandle, "FlagClustersAsPhotons", m_flagClustersAsPhotons));
 
-  // Get current Gaudi event to retrieve external clusters
-  // Retrieve the Gaudi event service from external parameters set by the parent algorithm
+  // Get the pointer to the external cluster holder
   // Sanghyun: this is a hacky way that I do this in ReadSettings
   // but GetExternalParameters doesn't allow me to access it more that once
   const ExternalEventParameter* pExternalEventParameter =
       dynamic_cast<const ExternalEventParameter*>(this->GetExternalParameters());
 
-  if (!pExternalEventParameter || !pExternalEventParameter->m_pEventService) {
-    throw std::runtime_error("DDExternalClusteringAlgorithm: External event parameter not set");
+  if (!pExternalEventParameter || !pExternalEventParameter->m_externalClusterHolder) {
+    throw std::runtime_error("DDExternalClusteringAlgorithm: External cluster holder not set");
   }
 
-  m_pEventService = pExternalEventParameter->m_pEventService;
+  m_externalClusterHolder = pExternalEventParameter->m_externalClusterHolder;
 
   return pandora::STATUS_CODE_SUCCESS;
 }

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -28,101 +28,150 @@
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterCollection.h"
 
-#include "DDExternalClusteringAlgorithm.h"
-#include "DDPandoraPFANewProcessor.h"
-
 #include "Pandora/AlgorithmHeaders.h"
-#include "XmlHelper.h"
 
-using namespace pandora;
+#include "DDExternalClusteringAlgorithm.h"
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/IDataProviderSvc.h"
+#include "GaudiKernel/AnyDataWrapper.h"
 
-DDExternalClusteringAlgorithm::DDExternalClusteringAlgorithm() : m_flagClustersAsPhotons(true) {}
+DDExternalClusteringAlgorithm::DDExternalClusteringAlgorithm() : m_flagClustersAsPhotons(false) {}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode DDExternalClusteringAlgorithm::Run() {
+pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
   try {
-    const CaloHitList* pCaloHitList = NULL;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
+    // Get Pandora calo hit list
+    const pandora::CaloHitList* pCaloHitList = NULL;
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pCaloHitList));
 
     if (pCaloHitList->empty())
-      return STATUS_CODE_SUCCESS;
-
-    // Get external photon cluster collection
-    const edm4hep::EventHeader* const pEventHeader = DDPandoraPFANewProcessor::GetCurrentEvent(&(this->GetPandora()));
-    const edm4hep::ClusterCollection* pExternalClusterCollection =
-        pEventHeader->getCollection(m_externalClusterCollectionName);
-    const unsigned int nExternalClusters(pExternalClusterCollection->size());
-
-    if (0 == nExternalClusters)
-      return STATUS_CODE_SUCCESS;
+      return pandora::STATUS_CODE_SUCCESS;
 
     // Populate pandora parent address to calo hit map
-    ParentAddressToCaloHitMap parentAddressToCaloHitMap;
+    ExternalToPandoraCaloHitMap caloHitMap;
 
-    for (CaloHitList::const_iterator hitIter = pCaloHitList->begin(), hitIterEnd = pCaloHitList->end();
+    for (pandora::CaloHitList::const_iterator hitIter = pCaloHitList->begin(), hitIterEnd = pCaloHitList->end();
          hitIter != hitIterEnd; ++hitIter) {
       const pandora::CaloHit* const pCaloHit = *hitIter;
-      parentAddressToCaloHitMap.insert(ParentAddressToCaloHitMap::value_type(pCaloHit->GetParentAddress(), pCaloHit));
+      const edm4hep::CalorimeterHit* edmCaloHit =
+          static_cast<const edm4hep::CalorimeterHit*>(pCaloHit->GetParentAddress());
+
+      caloHitMap.emplace(edmCaloHit->getCellID(), pCaloHit);
     }
+
+    // Get current Gaudi event to retrieve external clusters
+    // Retrieve the Gaudi event service from external parameters set by the parent algorithm
+    const ExternalEventParameter* pExternalEventParameter =
+        dynamic_cast<const ExternalEventParameter*>(this->GetExternalParameters());
+
+    if (!pExternalEventParameter || !pExternalEventParameter->m_pEventService) {
+      throw std::runtime_error("DDExternalClusteringAlgorithm: External event parameter not set");
+    }
+
+    auto* gaudiEvent = pExternalEventParameter->m_pEventService;
 
     // Recreate external clusters within the pandora framework
-    for (unsigned int iCluster = 0; iCluster < nExternalClusters; ++iCluster) {
-      const edm4hep::Cluster* const pExternalCluster = &pExternalClusterCollection->at(iCluster);
+    const pandora::ClusterList* pClusterList = nullptr;
 
-      if (nullptr == pExternalCluster)
-        throw std::runtime_error("Collection type mismatch");
+    std::string clusterListNameTmp = "ExternalClustersTmp";
+    std::string clusterListNameFinal = "ExternalClusters";
 
-      const std::vector<edm4hep::ConstCalorimeterHit> calorimeterHitVec = pExternalCluster->getHits();
+    PANDORA_RETURN_RESULT_IF(
+        pandora::STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListNameTmp));
 
-      const pandora::Cluster* pPandoraCluster = NULL;
+    // loop over external cluster collections
+    for (const auto& colName : m_externalClusterCollectionNames) {
+      DataObject* rawObj = nullptr;
+      StatusCode sc = gaudiEvent->retrieveObject("/Event/" + colName, rawObj);
 
-      for (auto iter = calorimeterHitVec.begin(), iterEnd = calorimeterHitVec.end(); iter != iterEnd; ++iter) {
-        ParentAddressToCaloHitMap::const_iterator pandoraCaloHitIter = parentAddressToCaloHitMap.find(iter->id());
-
-        if (parentAddressToCaloHitMap.end() == pandoraCaloHitIter) {
-          continue;
-        }
-
-        const pandora::CaloHit* const pPandoraCaloHit = pandoraCaloHitIter->second;
-
-        if (NULL == pPandoraCluster) {
-          PandoraContentApi::Cluster::Parameters parameters;
-          parameters.m_caloHitList.push_back(pPandoraCaloHit);
-          PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-                                   PandoraContentApi::Cluster::Create(*this, parameters, pPandoraCluster));
-
-          if (m_flagClustersAsPhotons) {
-            PandoraContentApi::Cluster::Metadata metadata;
-            metadata.m_particleId = PHOTON;
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-                                     PandoraContentApi::Cluster::AlterMetadata(*this, pPandoraCluster, metadata));
-          }
-        } else {
-          PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-                                   PandoraContentApi::AddToCluster(*this, pPandoraCluster, pPandoraCaloHit));
-        }
+      if (sc.isFailure() || rawObj == nullptr) {
+        throw std::runtime_error("DDExternalClusteringAlgorithm: Cannot retrieve the external cluster collection " + colName);
       }
+
+      auto anyWrapper = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(rawObj);
+
+      if (!anyWrapper) {
+        throw std::runtime_error("DDExternalClusteringAlgorithm: Failed to cast to AnyDataWrapper");
+      }
+
+      // get the underlying cluster collection
+      auto collBasePtr = anyWrapper->getData().get();
+      auto pExternalClusterCollection = dynamic_cast<edm4hep::ClusterCollection*>(collBasePtr);
+
+      if (!pExternalClusterCollection) {
+        throw std::runtime_error("DDExternalClusteringAlgorithm: Failed to cast CollectionBase to ClusterCollection");
+      }
+
+      // no cluster in this event
+      if (0 == pExternalClusterCollection->size())
+        continue;
+
+      // loop over external clusters
+      for (const edm4hep::Cluster& externalCluster : *pExternalClusterCollection) {
+        const auto& calorimeterHitVec = externalCluster.getHits();
+        pandora::CaloHitList pandoraHitList;
+
+        // find corresponding pandora hits
+        // and fill pandora calo hit list
+        for (const auto& edmHit : calorimeterHitVec) {
+          auto itr = caloHitMap.find(edmHit.getCellID());
+
+          if (itr == caloHitMap.end())
+            continue;
+
+          pandoraHitList.push_back(itr->second);
+        }
+
+        if (pandoraHitList.empty())
+          continue;
+
+        object_creation::ClusterParameters clusterParameters;
+        clusterParameters.m_caloHitList = pandoraHitList;
+
+        // create a pandora cluster
+        const pandora::Cluster* pPandoraCluster = nullptr;
+        PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                                PandoraContentApi::Cluster::Create(*this, clusterParameters, pPandoraCluster));
+
+        if (m_flagClustersAsPhotons) {
+          PandoraContentApi::Cluster::Metadata metadata;
+          metadata.m_particleId = pandora::PHOTON;
+          PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                                   PandoraContentApi::Cluster::AlterMetadata(*this, pPandoraCluster, metadata));
+        }
+      } // loop over external clusters
+    } // loop over external cluster collections
+
+    // need these to store the pandora cluster list
+    if (!pClusterList->empty()) {
+      PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                               PandoraContentApi::SaveList<pandora::Cluster>(*this, clusterListNameFinal));
+      PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                               PandoraContentApi::ReplaceCurrentList<pandora::Cluster>(*this, clusterListNameFinal));
     }
-  } catch (StatusCodeException& statusCodeException) {
+  } catch (pandora::StatusCodeException& statusCodeException) {
     return statusCodeException.GetStatusCode();
   } catch (std::exception& exception) {
-    std::cout << "DDExternalClusteringAlgorithm failure: " << exception.what() << std::endl;
-    return STATUS_CODE_FAILURE;
+    std::cerr << "DDExternalClusteringAlgorithm failure: " << exception.what() << std::endl;
+    return pandora::STATUS_CODE_FAILURE;
   }
 
-  return STATUS_CODE_SUCCESS;
+  return pandora::STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode DDExternalClusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle) {
+pandora::StatusCode DDExternalClusteringAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
   PANDORA_RETURN_RESULT_IF(
-      STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ReadValue(xmlHandle, "ExternalClusterCollectionName", m_externalClusterCollectionName));
+      pandora::STATUS_CODE_SUCCESS, !=,
+      pandora::XmlHelper::ReadVectorOfValues(xmlHandle, "ExternalClusterCollectionNames",
+                                             m_externalClusterCollectionNames));
 
-  PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-                                  XmlHelper::ReadValue(xmlHandle, "FlagClustersAsPhotons", m_flagClustersAsPhotons));
+  PANDORA_RETURN_RESULT_IF_AND_IF(
+      pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,
+      pandora::XmlHelper::ReadValue(xmlHandle, "FlagClustersAsPhotons", m_flagClustersAsPhotons));
 
-  return STATUS_CODE_SUCCESS;
+  return pandora::STATUS_CODE_SUCCESS;
 }

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -40,7 +40,7 @@ void ExternalClusterHolder::setExternalClusters(std::vector<std::vector<edm4hep:
   m_externalClusters = externalClusters;
 }
 
-const std::vector<std::vector<edm4hep::Cluster>> ExternalClusterHolder::getExternalClusters() const {
+const std::vector<std::vector<edm4hep::Cluster>>& ExternalClusterHolder::getExternalClusters() const {
   return *m_externalClusters;
 }
 

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -57,7 +57,7 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
       const edm4hep::CalorimeterHit* edmCaloHit =
           static_cast<const edm4hep::CalorimeterHit*>(pCaloHit->GetParentAddress());
 
-      caloHitMap.emplace(edmCaloHit->getCellID(), pCaloHit);
+      caloHitMap.emplace(edmCaloHit->id(), pCaloHit);
     }
 
     // Recreate external clusters within the pandora framework
@@ -106,7 +106,7 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
         // find corresponding pandora hits
         // and fill pandora calo hit list
         for (const auto& edmHit : calorimeterHitVec) {
-          auto itr = caloHitMap.find(edmHit.getCellID());
+          auto itr = caloHitMap.find(edmHit.id());
 
           if (itr == caloHitMap.end())
             continue;

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -32,8 +32,8 @@
 
 #include "DDExternalClusteringAlgorithm.h"
 #include "Gaudi/Algorithm.h"
-#include "GaudiKernel/IDataProviderSvc.h"
 #include "GaudiKernel/AnyDataWrapper.h"
+#include "GaudiKernel/IDataProviderSvc.h"
 
 DDExternalClusteringAlgorithm::DDExternalClusteringAlgorithm() : m_flagClustersAsPhotons(false) {}
 
@@ -76,7 +76,8 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
       StatusCode sc = m_pEventService->retrieveObject("/Event/" + colName, rawObj);
 
       if (sc.isFailure() || rawObj == nullptr) {
-        throw std::runtime_error("DDExternalClusteringAlgorithm: Cannot retrieve the external cluster collection " + colName);
+        throw std::runtime_error("DDExternalClusteringAlgorithm: Cannot retrieve the external cluster collection " +
+                                 colName);
       }
 
       auto anyWrapper = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(rawObj);
@@ -153,10 +154,9 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 pandora::StatusCode DDExternalClusteringAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle) {
-  PANDORA_RETURN_RESULT_IF(
-      pandora::STATUS_CODE_SUCCESS, !=,
-      pandora::XmlHelper::ReadVectorOfValues(xmlHandle, "ExternalClusterCollectionNames",
-                                             m_externalClusterCollectionNames));
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           pandora::XmlHelper::ReadVectorOfValues(xmlHandle, "ExternalClusterCollectionNames",
+                                                                  m_externalClusterCollectionNames));
 
   PANDORA_RETURN_RESULT_IF_AND_IF(
       pandora::STATUS_CODE_SUCCESS, pandora::STATUS_CODE_NOT_FOUND, !=,

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -88,7 +88,7 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
 
       // get the underlying cluster collection
       auto collBasePtr = anyWrapper->getData().get();
-      auto pExternalClusterCollection = dynamic_cast<edm4hep::ClusterCollection*>(collBasePtr);
+      auto pExternalClusterCollection = dynamic_cast<const edm4hep::ClusterCollection*>(collBasePtr);
 
       if (!pExternalClusterCollection) {
         throw std::runtime_error("DDExternalClusteringAlgorithm: Failed to cast CollectionBase to ClusterCollection");

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -51,9 +51,7 @@ pandora::StatusCode DDExternalClusteringAlgorithm::Run() {
     // Populate pandora parent address to calo hit map
     ExternalToPandoraCaloHitMap caloHitMap;
 
-    for (pandora::CaloHitList::const_iterator hitIter = pCaloHitList->begin(), hitIterEnd = pCaloHitList->end();
-         hitIter != hitIterEnd; ++hitIter) {
-      const pandora::CaloHit* const pCaloHit = *hitIter;
+    for (const auto* pCaloHit : *pCaloHitList) {
       const edm4hep::CalorimeterHit* edmCaloHit =
           static_cast<const edm4hep::CalorimeterHit*>(pCaloHit->GetParentAddress());
 

--- a/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
+++ b/k4GaudiPandora/src/DDExternalClusteringAlgorithm.cc
@@ -33,7 +33,6 @@
 #include "DDExternalClusteringAlgorithm.h"
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/AnyDataWrapper.h"
-#include "GaudiKernel/IDataProviderSvc.h"
 
 // setters and getters for the external cluster holder
 void ExternalClusterHolder::setExternalClusters(std::vector<std::vector<edm4hep::Cluster>>* externalClusters) {

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -128,6 +128,9 @@ StatusCode DDPandoraPFANewAlgorithm::initialize() {
     return StatusCode::FAILURE;
   }
 
+  // data service for the external clustering algorithm
+  m_dataSvc = Gaudi::Algorithm::eventSvc();
+
   finaliseSteeringParameters();
 
   if (m_settings.m_detectorName == "ALLEGRO") {

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -115,6 +115,7 @@ DDPandoraPFANewAlgorithm::DDPandoraPFANewAlgorithm(const std::string& name, ISvc
                            KeyValues("LCalCaloHitCollections", {}),
                            KeyValues("LHCalCaloHitCollections", {}),
                            KeyValues("RelCaloHitCollections", {}),
+                           KeyValues("ClusterCollections", {}),
                        },
                        {KeyValues("ClusterCollectionName", {"PandoraPFANewClusters"}),
                         KeyValues("PFOCollectionName", {"PandoraPFANewPFOs"}),
@@ -127,9 +128,6 @@ StatusCode DDPandoraPFANewAlgorithm::initialize() {
     error() << "Unable to retrieve the GeoSvc" << endmsg;
     return StatusCode::FAILURE;
   }
-
-  // data service for the external clustering algorithm
-  m_dataSvc = Gaudi::Algorithm::eventSvc();
 
   finaliseSteeringParameters();
 
@@ -162,9 +160,10 @@ StatusCode DDPandoraPFANewAlgorithm::initialize() {
                                                                new DDExternalClusteringAlgorithm::Factory))
 
   // Set external parameters for DDExternalClusteringAlgorithm
-  // This allows Pandora algorithms to access the Gaudi event service
+  // everything is owned by this algorithm
   m_extEvtParam = std::make_unique<ExternalEventParameter>();
-  m_extEvtParam->m_pEventService = m_dataSvc.get();
+  m_extClusterHolder = std::make_unique<ExternalClusterHolder>();
+  m_extEvtParam->m_externalClusterHolder = m_extClusterHolder.get();
 
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
                           PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", m_extEvtParam.get()))
@@ -189,7 +188,8 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& mCalCollections,
                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& lCalCollections,
                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& lhCalCollections,
-                                     const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&) const {
+                                     const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&,
+                                     const std::vector<const edm4hep::ClusterCollection*>& clusterCollections) const {
   try {
     std::vector<edm4hep::MCParticle> mcParticlesVector;
     for (const auto& mcParticleCollection : MCParticleCollections) {
@@ -256,6 +256,25 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                             m_caloHitCreator->createCaloHits(eCalHitCollectionsMap, hCalHitCollectionsVector,
                                                              mCalHitCollectionsVector, lCalHitCollectionsVector,
                                                              lhCalHitCollectionsVector))
+
+    // host edm4hep clusters for the external clustering algorithm
+    std::unique_ptr<std::vector<std::vector<edm4hep::Cluster>>> externalClustersPtr =
+        std::make_unique<std::vector<std::vector<edm4hep::Cluster>>>();
+    externalClustersPtr->reserve(clusterCollections.size());
+
+    // loop over the input cluster collections and fill the external clusters vector
+    for (const auto* clusterCollection : clusterCollections) {
+      std::vector<edm4hep::Cluster> clusterValues;
+      clusterValues.reserve(clusterCollection->size());
+
+      for (const auto& cluster : *clusterCollection) {
+        clusterValues.push_back(cluster);
+      }
+
+      externalClustersPtr->push_back(std::move(clusterValues));
+    }
+
+    m_extClusterHolder->setExternalClusters(externalClustersPtr.get());
 
     // PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
     //                         m_pDDMCParticleCreator->CreateCaloHitToMCParticleRelationships(

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -31,9 +31,9 @@
 
 #include "DDBFieldPlugin.h"
 
+#include "DDExternalClusteringAlgorithm.h"
 #include "DDTrackCreatorCLIC.h"
 #include "DDTrackCreatorILD.h"
-#include "DDExternalClusteringAlgorithm.h"
 
 #include <Api/PandoraApi.h>
 #include <LCContent.h>

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -33,6 +33,7 @@
 
 #include "DDTrackCreatorCLIC.h"
 #include "DDTrackCreatorILD.h"
+#include "DDExternalClusteringAlgorithm.h"
 
 #include <Api/PandoraApi.h>
 #include <LCContent.h>
@@ -173,7 +174,6 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& lhCalCollections,
                                      const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&) const {
   try {
-
     std::vector<edm4hep::MCParticle> mcParticlesVector;
     for (const auto& mcParticleCollection : MCParticleCollections) {
       mcParticlesVector.insert(mcParticlesVector.end(), mcParticleCollection->begin(), mcParticleCollection->end());
@@ -245,6 +245,14 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
     //                             caloLinkCollections, m_pCaloHitCreator->GetCalorimeterHitVector(), eCalCollections,
     //                             hCalCollections, mCalCollections, lCalCollections, lhCalCollections))
 
+    // Set external parameters for DDExternalClusteringAlgorithm
+    // This allows Pandora algorithms to access the Gaudi event service
+    ExternalEventParameter externalEventParameter;
+    externalEventParameter.m_pEventService = Gaudi::Algorithm::eventSvc().get();
+
+    PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                            PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", &externalEventParameter))
+
     PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(m_pPandora))
 
     edm4hep::ClusterCollection pClusterCollection;
@@ -281,6 +289,11 @@ const pandora::Pandora* DDPandoraPFANewAlgorithm::GetPandora() const {
 pandora::StatusCode DDPandoraPFANewAlgorithm::registerUserComponents() const {
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterAlgorithms(m_pPandora))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterBasicPlugins(m_pPandora))
+
+  // Register DDExternalClusteringAlgorithm
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                           PandoraApi::RegisterAlgorithmFactory(m_pPandora, "DDExternalClustering",
+                                                                new DDExternalClusteringAlgorithm::Factory))
 
   if (m_settings.m_useDD4hepField) {
     dd4hep::Detector& mainDetector = dd4hep::Detector::getInstance();

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -152,6 +152,20 @@ StatusCode DDPandoraPFANewAlgorithm::initialize() {
   m_pfoCreator = std::make_unique<DDPfoCreator>(m_pfoCreatorSettings, m_pPandora, this);
 
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, registerUserComponents())
+
+  // Register DDExternalClusteringAlgorithm
+  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                          PandoraApi::RegisterAlgorithmFactory(m_pPandora, "DDExternalClustering",
+                                                               new DDExternalClusteringAlgorithm::Factory))
+
+  // Set external parameters for DDExternalClusteringAlgorithm
+  // This allows Pandora algorithms to access the Gaudi event service
+  m_extEvtParam = std::make_unique<ExternalEventParameter>();
+  m_extEvtParam->m_pEventService = m_dataSvc.get();
+
+  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                          PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", m_extEvtParam.get()))
+
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, m_geometryCreator->CreateGeometry())
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
                           PandoraApi::ReadSettings(m_pPandora, m_settings.m_pandoraSettingsXmlFile))
@@ -281,19 +295,6 @@ const pandora::Pandora* DDPandoraPFANewAlgorithm::GetPandora() const {
 pandora::StatusCode DDPandoraPFANewAlgorithm::registerUserComponents() const {
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterAlgorithms(m_pPandora))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterBasicPlugins(m_pPandora))
-
-  // Register DDExternalClusteringAlgorithm
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                           PandoraApi::RegisterAlgorithmFactory(m_pPandora, "DDExternalClustering",
-                                                                new DDExternalClusteringAlgorithm::Factory))
-
-  // Set external parameters for DDExternalClusteringAlgorithm
-  // This allows Pandora algorithms to access the Gaudi event service
-  m_extEvtParam = std::make_unique<ExternalEventParameter>();
-  m_extEvtParam->m_pEventService = m_dataSvc.get();
-
-  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                          PandoraApi::SetExternalParameters(m_pandora, "DDExternalClustering", m_extEvtParam.get()))
 
   if (m_settings.m_useDD4hepField) {
     dd4hep::Detector& mainDetector = dd4hep::Detector::getInstance();

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -245,14 +245,6 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
     //                             caloLinkCollections, m_pCaloHitCreator->GetCalorimeterHitVector(), eCalCollections,
     //                             hCalCollections, mCalCollections, lCalCollections, lhCalCollections))
 
-    // Set external parameters for DDExternalClusteringAlgorithm
-    // This allows Pandora algorithms to access the Gaudi event service
-    ExternalEventParameter externalEventParameter;
-    externalEventParameter.m_pEventService = Gaudi::Algorithm::eventSvc().get();
-
-    PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                            PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", &externalEventParameter))
-
     PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(m_pPandora))
 
     edm4hep::ClusterCollection pClusterCollection;
@@ -294,6 +286,14 @@ pandora::StatusCode DDPandoraPFANewAlgorithm::registerUserComponents() const {
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
                            PandoraApi::RegisterAlgorithmFactory(m_pPandora, "DDExternalClustering",
                                                                 new DDExternalClusteringAlgorithm::Factory))
+
+  // Set external parameters for DDExternalClusteringAlgorithm
+  // This allows Pandora algorithms to access the Gaudi event service
+  m_extEvtParam = std::make_unique<ExternalEventParameter>();
+  m_extEvtParam->m_pEventService = m_dataSvc.get();
+
+  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                          PandoraApi::SetExternalParameters(m_pandora, "DDExternalClustering", m_extEvtParam.get()))
 
   if (m_settings.m_useDD4hepField) {
     dd4hep::Detector& mainDetector = dd4hep::Detector::getInstance();

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -258,7 +258,7 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                                                              lhCalHitCollectionsVector))
 
     // host edm4hep clusters for the external clustering algorithm
-    std::unique_ptr<std::vector<std::vector<edm4hep::Cluster>>> externalClustersPtr =
+    auto externalClustersPtr =
         std::make_unique<std::vector<std::vector<edm4hep::Cluster>>>();
     externalClustersPtr->reserve(clusterCollections.size());
 

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -258,8 +258,7 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                                                              lhCalHitCollectionsVector))
 
     // host edm4hep clusters for the external clustering algorithm
-    auto externalClustersPtr =
-        std::make_unique<std::vector<std::vector<edm4hep::Cluster>>>();
+    auto externalClustersPtr = std::make_unique<std::vector<std::vector<edm4hep::Cluster>>>();
     externalClustersPtr->reserve(clusterCollections.size());
 
     // loop over the input cluster collections and fill the external clusters vector

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -160,13 +160,16 @@ StatusCode DDPandoraPFANewAlgorithm::initialize() {
                                                                new DDExternalClusteringAlgorithm::Factory))
 
   // Set external parameters for DDExternalClusteringAlgorithm
-  // everything is owned by this algorithm
-  m_extEvtParam = std::make_unique<ExternalEventParameter>();
-  m_extClusterHolder = std::make_unique<ExternalClusterHolder>();
-  m_extEvtParam->m_externalClusterHolder = m_extClusterHolder.get();
+  // ExternalClusterHolder is owned by this algorithm
+  // ExternalEventParameter is created by this algo and deleted by Pandora
+  if (!inputLocations("ClusterCollections").empty()) {
+    m_extEvtParam = new ExternalEventParameter();
+    m_extClusterHolder = std::make_unique<ExternalClusterHolder>();
+    m_extEvtParam->m_externalClusterHolder = m_extClusterHolder.get();
 
-  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                          PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", m_extEvtParam.get()))
+    PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                            PandoraApi::SetExternalParameters(m_pPandora, "DDExternalClustering", m_extEvtParam))
+  }
 
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, m_geometryCreator->CreateGeometry())
   PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
@@ -261,19 +264,21 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
     auto externalClustersPtr = std::make_unique<std::vector<std::vector<edm4hep::Cluster>>>();
     externalClustersPtr->reserve(clusterCollections.size());
 
-    // loop over the input cluster collections and fill the external clusters vector
-    for (const auto* clusterCollection : clusterCollections) {
-      std::vector<edm4hep::Cluster> clusterValues;
-      clusterValues.reserve(clusterCollection->size());
+    if (!clusterCollections.empty()) {
+      // loop over the input cluster collections and fill the external clusters vector
+      for (const auto* clusterCollection : clusterCollections) {
+        std::vector<edm4hep::Cluster> clusterValues;
+        clusterValues.reserve(clusterCollection->size());
 
-      for (const auto& cluster : *clusterCollection) {
-        clusterValues.push_back(cluster);
+        for (const auto& cluster : *clusterCollection) {
+          clusterValues.push_back(cluster);
+        }
+
+        externalClustersPtr->push_back(std::move(clusterValues));
       }
 
-      externalClustersPtr->push_back(std::move(clusterValues));
+      m_extClusterHolder->setExternalClusters(externalClustersPtr.get());
     }
-
-    m_extClusterHolder->setExternalClusters(externalClustersPtr.get());
 
     // PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
     //                         m_pDDMCParticleCreator->CreateCaloHitToMCParticleRelationships(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,3 +105,9 @@ add_test(NAME "compare_DDSimpleMuonDigi"
 set_test_env("compare_DDSimpleMuonDigi")
 set_tests_properties("compare_DDSimpleMuonDigi" PROPERTIES DEPENDS "run_DDSimpleMuonDigi")
 
+add_test(NAME "run_Pandora_externalClustering"
+  COMMAND k4run ${PROJECT_SOURCE_DIR}/k4GaudiPandora/options/runExternalClustering.py --IOSvc.Input output_pandora_ttbar.root --IOSvc.Output output_pandora_externalClustering.root
+)
+set_test_env("run_Pandora_externalClustering")
+set_tests_properties("run_Pandora_externalClustering" PROPERTIES DEPENDS "run_Pandora_ttbar")
+


### PR DESCRIPTION
BEGINRELEASENOTES
- Enabled `DDExternalClusteringAlgorithm`. The static getter function from the previous `DDPandoraPFANewProcessor` has been removed by turning the algorithm into `pandora::ExternallyConfiguredAlgorithm`.

ENDRELEASENOTES

There are some parties interested in the `DDExternalClusteringAlgorithm` (the IDEA and k4Clue community). This PR revives back the external clustering algorithm. As a consideration for another potential Gaudi functional `DDPandoraPFAXXXAlgorithm` to run the IDEA reconstruction chain (and as a general rule of thumb of c++ application), the static getter function from the previous `DDPandoraPFANewProcessor` has been removed. The algorithm has become `pandora::ExternallyConfiguredAlgorithm` so that the external cluster collection can be retrieved by `pandora::ExternalParameters` and Gaudi `IDataProviderSvc`.