### PR TITLE
Switch to the new utility for retrieving cell id encoding

### DIFF
--- a/k4GaudiPandora/src/DDCaloDigi.cc
+++ b/k4GaudiPandora/src/DDCaloDigi.cc
@@ -269,7 +269,7 @@ retType DDCaloDigi::operator()(const edm4hep::SimCalorimeterHitCollection& simCa
 
   const CHT::Layout caloLayout = layoutFromString(colName);
 
-  const auto maybeParam = k4FWCore::getParameter<std::string>(colName + "__CellIDEncoding");
+  const auto maybeParam = k4FWCore::getCellIDEncoding(colName, this);
   const auto initString = maybeParam.value();
   dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString); // check if decoder contains "layer"
 

--- a/k4GaudiPandora/src/DDSimpleMuonDigi.cc
+++ b/k4GaudiPandora/src/DDSimpleMuonDigi.cc
@@ -24,7 +24,6 @@
 
 #include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
 #include <edm4hep/CalorimeterHitCollection.h>
-#include <edm4hep/Constants.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 
@@ -95,8 +94,7 @@ StatusCode DDSimpleMuonDigi::initialize() {
   }
 
   const auto collName = inputLocations("MUONCollection")[0];
-  const auto encodingString =
-      k4FWCore::getParameter<std::string>(collName + "__" + edm4hep::labels::CellIDEncoding, this);
+  const auto encodingString = k4FWCore::getCellIDEncoding(collName, this);
   if (!encodingString) {
     throw std::runtime_error("Encoding string not found for collection: " + collName);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the newly added `k4FWCore::getCellIDEncoding` utility for retrieving the cell id encoding. 

ENDRELEASENOTES

This fixes a deprecation warning in passing.
- [x] Needs https://github.com/key4hep/k4FWCore/pull/391
