### PR TITLE
Use a single output in the CollectionMerger since this is going be changed in k4FWCore

### DIFF
--- a/k4GaudiPandora/options/runDDCaloDigi.py
+++ b/k4GaudiPandora/options/runDDCaloDigi.py
@@ -165,7 +165,7 @@ merger = CollectionMerger(
         "GaudiLinkCaloHitHCALEndcap",
         "GaudiLinkCaloHitHCALRing",
     ],
-    OutputCollection=["GaudiRelationCaloHit"],
+    OutputCollection="GaudiRelationCaloHit",
 )
 
 hps = RootHistSvc("HistogramPersistencySvc")

--- a/k4GaudiPandora/options/runDDSimpleMuonDigi.py
+++ b/k4GaudiPandora/options/runDDSimpleMuonDigi.py
@@ -67,11 +67,11 @@ for alg, inputcol, outputcol, outrel in zip(
 # the single one that is obtained by original Marlin processor
 merger = CollectionMerger("MuonYokeMerger")
 merger.InputCollections = output_collections
-merger.OutputCollection = ["GaudiMUON"]
+merger.OutputCollection = "GaudiMUON"
 
 relation_merger = CollectionMerger("MuonRelationMerger")
 relation_merger.InputCollections = output_relation
-relation_merger.OutputCollection = ["GaudiRelationMUON"]
+relation_merger.OutputCollection = "GaudiRelationMUON"
 
 ApplicationMgr(
     TopAlg=digi + [merger, relation_merger],


### PR DESCRIPTION
BEGINRELEASENOTES
- Use a single output in the CollectionMerger since this is going be changed in k4FWCore in https://github.com/key4hep/k4FWCore/pull/408

ENDRELEASENOTES