### PR TITLE
Changes for ALLEGRO [WIP]

### DIFF
--- a/k4GaudiPandora/include/DDCaloHitCreator.h
+++ b/k4GaudiPandora/include/DDCaloHitCreator.h
@@ -37,6 +37,12 @@
 typedef std::vector<edm4hep::CalorimeterHit> CalorimeterHitVector;
 typedef std::vector<const edm4hep::CalorimeterHitCollection*> HitCollectionVector;
 
+struct CollectionDescriptor {
+  std::string collectionName;
+  std::string cellIDEncoding;
+  const std::vector<edm4hep::CalorimeterHit>* collection;
+};
+
 /**
  *  @brief  DDCaloHitCreator class
  */
@@ -114,9 +120,11 @@ public:
     float m_hCalBarrelOuterR;               ///< HCal barrel outer radius
     float m_hCalBarrelOuterPhi0;            ///< HCal barrel outer phi0 coordinate
     unsigned int m_hCalBarrelOuterSymmetry; ///< HCal barrel outer symmetry order
+    std::string m_detectorName;             ///< to handle detector-specific settings
     bool m_useSystemId;                     ///< flag whether to use systemId or not to identify origin of the CaloHit
     int m_ecalBarrelSystemId;               ///< systemId of ECal Barrel
     int m_hcalBarrelSystemId;               ///< systemId of HCal Barrel
+    int m_hcalEndcapSystemId;               ///< systemId of HCal Endcap
 
   public:
     FloatVector m_eCalBarrelNormalVector;
@@ -134,10 +142,9 @@ public:
   DDCaloHitCreator(const Settings& settings, pandora::Pandora& pandora, const Gaudi::Algorithm* algorithm);
   virtual ~DDCaloHitCreator();
 
-  pandora::StatusCode
-  createECalCaloHits(const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& inputECalCaloHits) const;
-  pandora::StatusCode createHCalCaloHits(const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits) const;
-  pandora::StatusCode createMuonCaloHits(const std::vector<edm4hep::CalorimeterHit>& muonCaloHits) const;
+  pandora::StatusCode createECalCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits) const;
+  pandora::StatusCode createHCalCaloHits(const std::vector<CollectionDescriptor>& hCalCaloHits) const;
+  pandora::StatusCode createMuonCaloHits(const std::vector<CollectionDescriptor>& muonCaloHits) const;
   pandora::StatusCode createLCalCaloHits(const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits) const;
   pandora::StatusCode createLHCalCaloHits(const std::vector<edm4hep::CalorimeterHit>& LHCalCaloHits) const;
 
@@ -147,12 +154,11 @@ public:
    *  @param  inputHits
    *  @param  outputHits
    */
-  virtual pandora::StatusCode
-  createCaloHits(const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& eCaloHitsMap,
-                 const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& muonCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const;
+  virtual pandora::StatusCode createCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits,
+                                             const std::vector<CollectionDescriptor>& hCalCaloHits,
+                                             const std::vector<CollectionDescriptor>& muonCaloHits,
+                                             const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
+                                             const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const;
 
   /**
    *  @brief  Get the calorimeter hit vector
@@ -173,8 +179,8 @@ protected:
    *  @param  pCaloHit the lcio calorimeter hit
    *  @param  caloHitParameters the calo hit parameters to populate
    */
-  void getCommonCaloHitProperties(const edm4hep::CalorimeterHit& hit,
-                                  PandoraApi::CaloHit::Parameters& caloHitParameters) const;
+  virtual void getCommonCaloHitProperties(const edm4hep::CalorimeterHit& hit,
+                                          PandoraApi::CaloHit::Parameters& caloHitParameters) const;
 
   /**
    *  @brief  Get end cap specific calo hit properties: cell size, absorber radiation and interaction lengths, normal
@@ -185,9 +191,10 @@ protected:
    *  @param  caloHitParameters the calo hit parameters to populate
    *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
    */
-  void getEndCapCaloHitProperties(const edm4hep::CalorimeterHit& hit,
-                                  const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
-                                  PandoraApi::CaloHit::Parameters& caloHitParameters, float& absorberCorrection) const;
+  virtual void getEndCapCaloHitProperties(const edm4hep::CalorimeterHit& hit,
+                                          const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+                                          PandoraApi::CaloHit::Parameters& caloHitParameters,
+                                          float& absorberCorrection) const;
 
   /**
    *  @brief  Get barrel specific calo hit properties: cell size, absorber radiation and interaction lengths, normal
@@ -200,10 +207,11 @@ protected:
    *  @param  normalVector is the normalVector to the sensitive layers in local coordinates
    *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
    */
-  void getBarrelCaloHitProperties(const edm4hep::CalorimeterHit& hit,
-                                  const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
-                                  unsigned int barrelSymmetryOrder, PandoraApi::CaloHit::Parameters& caloHitParameters,
-                                  const std::vector<float>& normalVector, float& absorberCorrection) const;
+  virtual void getBarrelCaloHitProperties(const edm4hep::CalorimeterHit& hit,
+                                          const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+                                          unsigned int barrelSymmetryOrder,
+                                          PandoraApi::CaloHit::Parameters& caloHitParameters,
+                                          const std::vector<float>& normalVector, float& absorberCorrection) const;
 
   /**
    *  @brief  Get number of active layers from position of a calo hit to the edge of the detector

--- a/k4GaudiPandora/include/DDCaloHitCreatorALLEGRO.h
+++ b/k4GaudiPandora/include/DDCaloHitCreatorALLEGRO.h
@@ -51,12 +51,11 @@ public:
    *
    *  @param  pLCEvent the lcio event
    */
-  virtual pandora::StatusCode
-  createCaloHits(const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& eCaloHitsMap,
-                 const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& muonCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
-                 const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const override;
+  virtual pandora::StatusCode createCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits,
+                                             const std::vector<CollectionDescriptor>& hCalCaloHits,
+                                             const std::vector<CollectionDescriptor>& muonCaloHits,
+                                             const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
+                                             const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const override;
 
 private:
   /**
@@ -66,6 +65,41 @@ private:
    *  @param  caloHitParameters the calo hit parameters to populate
    */
   void getCommonCaloHitProperties(const edm4hep::CalorimeterHit& hit,
-                                  PandoraApi::CaloHit::Parameters& caloHitParameters) const;
+                                  PandoraApi::CaloHit::Parameters& caloHitParameters) const override;
+
+  /**
+   *  @brief  Get end cap specific calo hit properties: cell size, absorber radiation and interaction lengths, normal
+   * vector
+   *
+   *  @param  pCaloHit the lcio calorimeter hit
+   *  @param  layers the vector of layers from DDRec extensions
+   *  @param  caloHitParameters the calo hit parameters to populate
+   *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
+   */
+  virtual void getEndCapCaloHitProperties(const edm4hep::CalorimeterHit& hit,
+                                          const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+                                          PandoraApi::CaloHit::Parameters& caloHitParameters,
+                                          float& absorberCorrection) const override;
+
+  /**
+   *  @brief  Get barrel specific calo hit properties: cell size, absorber radiation and interaction lengths, normal
+   * vector
+   *
+   *  @param  pCaloHit the lcio calorimeter hit
+   *  @param  layers the vector of layers from DDRec extensions
+   *  @param  barrelSymmetryOrder the barrel order of symmetry
+   *  @param  caloHitParameters the calo hit parameters to populate
+   *  @param  normalVector is the normalVector to the sensitive layers in local coordinates
+   *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
+   */
+  virtual void getBarrelCaloHitProperties(const edm4hep::CalorimeterHit& hit,
+                                          const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+                                          unsigned int barrelSymmetryOrder,
+                                          PandoraApi::CaloHit::Parameters& caloHitParameters,
+                                          const std::vector<float>& normalVector,
+                                          float& absorberCorrection) const override;
+
+  std::shared_ptr<dd4hep::DDSegmentation::Segmentation> m_hcalBarrelSegmentation = {};
+  std::shared_ptr<dd4hep::DDSegmentation::Segmentation> m_hcalEndcapSegmentation = {};
 };
 #endif

--- a/k4GaudiPandora/include/DDCaloHitCreatorALLEGRO.h
+++ b/k4GaudiPandora/include/DDCaloHitCreatorALLEGRO.h
@@ -99,6 +99,16 @@ private:
                                           const std::vector<float>& normalVector,
                                           float& absorberCorrection) const override;
 
+  /**
+   *  @brief  Convert delta theta to delta eta. This conversion is needed because PandoraSDK
+   *  provides POINTING cell geometry assuming a DeltaEta segmentation, while in ALLEGRO we have the DeltaTheta segmentation.
+   *
+   *  @param  deltaTheta the delta theta in radians
+   *  @param  position the hit position to calculate the theta angle
+   *  @return the delta eta
+   */
+  double convertDeltaThetaToDeltaEta(double deltaTheta, double theta) const;
+
   std::shared_ptr<dd4hep::DDSegmentation::Segmentation> m_hcalBarrelSegmentation = {};
   std::shared_ptr<dd4hep::DDSegmentation::Segmentation> m_hcalEndcapSegmentation = {};
 };

--- a/k4GaudiPandora/include/DDGeometryCreator.h
+++ b/k4GaudiPandora/include/DDGeometryCreator.h
@@ -46,7 +46,7 @@ public:
    */
   DDGeometryCreator(const Settings& settings, pandora::Pandora& pandora, Gaudi::Algorithm* algorithm);
 
-  pandora::StatusCode CreateGeometry() const;
+  virtual pandora::StatusCode CreateGeometry() const;
 
 protected:
   typedef std::map<pandora::SubDetectorType, PandoraApi::Geometry::SubDetector::Parameters> SubDetectorTypeMap;
@@ -56,7 +56,7 @@ protected:
    *
    *  @param  subDetectorTypeMap the sub detector type map
    */
-  void SetMandatorySubDetectorParameters(SubDetectorTypeMap& subDetectorTypeMap) const;
+  virtual void SetMandatorySubDetectorParameters(SubDetectorTypeMap& subDetectorTypeMap) const;
 
   /**
    *  @brief  Set additional sub detector parameters

--- a/k4GaudiPandora/include/DDGeometryCreatorALLEGRO.h
+++ b/k4GaudiPandora/include/DDGeometryCreatorALLEGRO.h
@@ -50,7 +50,7 @@ public:
   /**
    *  @brief  Create geometry
    */
-  pandora::StatusCode CreateGeometry() const;
+  pandora::StatusCode CreateGeometry() const override;
 
 private:
   /**
@@ -58,7 +58,7 @@ private:
    *
    *  @param  subDetectorTypeMap the sub detector type map
    */
-  void SetMandatorySubDetectorParameters(SubDetectorTypeMap& subDetectorTypeMap) const;
+  void SetMandatorySubDetectorParameters(SubDetectorTypeMap& subDetectorTypeMap) const override;
 };
 
 #endif // #ifndef GEOMETRY_CREATOR_H

--- a/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
+++ b/k4GaudiPandora/include/DDPandoraPFANewAlgorithm.h
@@ -360,6 +360,7 @@ private:
       "The name of the DD4hep constant that contains the Encoding string for the Calo detectors"};
   /// EXTRA parameter that would initialize everything for ALLEGRO detector if m_detectorName=="ALLEGRO"
   Gaudi::Property<std::string> m_detectorName{this, "DetectorName", "", "The name of the detector"};
+
   Gaudi::Property<std::vector<float>> m_eCalBarrelNormalVector{
       this,
       "ECalBarrelNormalVector",

--- a/k4GaudiPandora/src/DDCaloHitCreator.cc
+++ b/k4GaudiPandora/src/DDCaloHitCreator.cc
@@ -76,13 +76,12 @@ DDCaloHitCreator::DDCaloHitCreator(const Settings& settings, pandora::Pandora& p
 
 DDCaloHitCreator::~DDCaloHitCreator() = default;
 
-pandora::StatusCode
-DDCaloHitCreator::createCaloHits(const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& eCaloHitsMap,
-                                 const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits,
-                                 const std::vector<edm4hep::CalorimeterHit>& muonCaloHits,
-                                 const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
-                                 const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const {
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createECalCaloHits(eCaloHitsMap))
+pandora::StatusCode DDCaloHitCreator::createCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits,
+                                                     const std::vector<CollectionDescriptor>& hCalCaloHits,
+                                                     const std::vector<CollectionDescriptor>& muonCaloHits,
+                                                     const std::vector<edm4hep::CalorimeterHit>& lCalCaloHits,
+                                                     const std::vector<edm4hep::CalorimeterHit>& lhCalCaloHits) const {
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createECalCaloHits(eCalCaloHits))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createHCalCaloHits(hCalCaloHits))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createMuonCaloHits(muonCaloHits))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createLCalCaloHits(lCalCaloHits))
@@ -92,16 +91,27 @@ DDCaloHitCreator::createCaloHits(const std::map<std::string, std::vector<edm4hep
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-pandora::StatusCode DDCaloHitCreator::createECalCaloHits(
-    const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& inputECalCaloHits) const {
+pandora::StatusCode DDCaloHitCreator::createECalCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits) const {
+  if (eCalCaloHits.empty())
+    return pandora::STATUS_CODE_SUCCESS;
 
   std::string initString = "system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16";
-  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
 
-  for (const auto& [originalCollectionName, hits] : inputECalCaloHits) {
-    if (hits.empty()) {
+  for (const auto& hits : eCalCaloHits) {
+    if (hits.collection->empty()) {
       continue;
     }
+    // AD: for ALLEGRO detector the above hardcoded cellID encoding does not work, so we need to extract it from the
+    // input collection
+    if (m_settings.m_detectorName == "ALLEGRO") {
+      initString = hits.cellIDEncoding;
+      if (initString.empty())
+        m_algorithm.error() << "Cannot get cellIDEncoding string for " << hits.collectionName << endmsg;
+      m_algorithm.debug() << "Extracted cellIDEncoding string for " << hits.collectionName << " : " << initString
+                          << endmsg;
+    }
+    dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
+
     const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& barrelLayers =
         getExtension((dd4hep::DetType::CALORIMETER | dd4hep::DetType::ELECTROMAGNETIC | dd4hep::DetType::BARREL),
                      (dd4hep::DetType::AUXILIARY | dd4hep::DetType::FORWARD))
@@ -111,12 +121,14 @@ pandora::StatusCode DDCaloHitCreator::createECalCaloHits(
                      (dd4hep::DetType::AUXILIARY | dd4hep::DetType::FORWARD))
             ->layers;
 
-    if (barrelLayers.empty() || endcapLayers.empty()) {
+    // FIXME: AD: currently in ALLEGRO we do not have endcap layers, so this check is disabled for ALLEGRO
+    if (m_settings.m_detectorName != "ALLEGRO" && (barrelLayers.empty() || endcapLayers.empty())) {
       m_algorithm.error() << "Layer information missing for ECAL!" << endmsg;
       return pandora::STATUS_CODE_FAILURE;
     }
 
-    for (const auto& hit : hits) {
+    std::string originalCollectionName = hits.collectionName;
+    for (const auto& hit : *hits.collection) {
       try {
 
         float absorberCorrection = 1.0;
@@ -196,9 +208,7 @@ pandora::StatusCode DDCaloHitCreator::createECalCaloHits(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-pandora::StatusCode
-DDCaloHitCreator::createHCalCaloHits(const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits) const {
-
+pandora::StatusCode DDCaloHitCreator::createHCalCaloHits(const std::vector<CollectionDescriptor>& hCalCaloHits) const {
   if (hCalCaloHits.empty())
     return pandora::STATUS_CODE_SUCCESS;
 
@@ -218,40 +228,63 @@ DDCaloHitCreator::createHCalCaloHits(const std::vector<edm4hep::CalorimeterHit>&
   }
 
   std::string initString = "system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16";
-  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
 
-  for (const auto& hit : hCalCaloHits) {
-    try {
-      PandoraApi::CaloHit::Parameters caloHitParameters;
-      caloHitParameters.m_hitType = pandora::HCAL;
-      caloHitParameters.m_isDigital = false;
-      caloHitParameters.m_layer = bitFieldCoder.get(hit.getCellID(), "layer");
-      caloHitParameters.m_isInOuterSamplingLayer = (this->getNLayersFromEdge(hit) <= m_settings.m_nOuterSamplingLayers);
-      this->getCommonCaloHitProperties(hit, caloHitParameters);
+  for (const auto& hits : hCalCaloHits) {
+    if (hits.collection->empty()) {
+      continue;
+    }
+    // AD: for ALLEGRO detector the above hardcoded cellID encoding does not work, so we need to extract it from the
+    // input collection
+    if (m_settings.m_detectorName == "ALLEGRO") {
+      initString = hits.cellIDEncoding;
+      if (initString.empty())
+        m_algorithm.error() << "Cannot get cellIDEncoding string for " << hits.collectionName << endmsg;
+      m_algorithm.debug() << "Extracted cellIDEncoding string for " << hits.collectionName << " : " << initString
+                          << endmsg;
+    }
+    dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
 
-      float absorberCorrection = 1.0;
+    for (const auto& hit : *hits.collection) {
+      try {
+        PandoraApi::CaloHit::Parameters caloHitParameters;
+        caloHitParameters.m_hitType = pandora::HCAL;
+        caloHitParameters.m_isDigital = false;
+        caloHitParameters.m_layer = bitFieldCoder.get(hit.getCellID(), "layer");
+        if (m_settings.m_detectorName == "ALLEGRO" &&
+            bitFieldCoder.get(hit.getCellID(), "system") == m_settings.m_hcalEndcapSystemId) {
+          caloHitParameters.m_layer = bitFieldCoder.get(hit.getCellID(), "pseudoLayer");
+        }
 
-      if (std::fabs(hit.getPosition()[2]) < m_settings.m_hCalBarrelOuterZ) {
-        this->getBarrelCaloHitProperties(hit, barrelLayers, m_settings.m_hCalBarrelInnerSymmetry, caloHitParameters,
-                                         m_settings.m_hCalBarrelNormalVector, absorberCorrection);
-      } else {
-        this->getEndCapCaloHitProperties(hit, endcapLayers, caloHitParameters, absorberCorrection);
+        caloHitParameters.m_isInOuterSamplingLayer =
+            (this->getNLayersFromEdge(hit) <= m_settings.m_nOuterSamplingLayers);
+        this->getCommonCaloHitProperties(hit, caloHitParameters);
+
+        float absorberCorrection = 1.0;
+
+        if ((!m_settings.m_useSystemId && std::fabs(hit.getPosition()[2]) < m_settings.m_hCalBarrelOuterZ) ||
+            (m_settings.m_useSystemId &&
+             bitFieldCoder.get(hit.getCellID(), "system") == m_settings.m_hcalBarrelSystemId)) {
+          this->getBarrelCaloHitProperties(hit, barrelLayers, m_settings.m_hCalBarrelInnerSymmetry, caloHitParameters,
+                                           m_settings.m_hCalBarrelNormalVector, absorberCorrection);
+        } else {
+          this->getEndCapCaloHitProperties(hit, endcapLayers, caloHitParameters, absorberCorrection);
+        }
+
+        caloHitParameters.m_mipEquivalentEnergy = hit.getEnergy() * m_settings.m_hCalToMip * absorberCorrection;
+
+        if (caloHitParameters.m_mipEquivalentEnergy.Get() < m_settings.m_hCalMipThreshold)
+          continue;
+
+        caloHitParameters.m_hadronicEnergy =
+            std::min(m_settings.m_hCalToHadGeV * hit.getEnergy(), m_settings.m_maxHCalHitHadronicEnergy);
+        caloHitParameters.m_electromagneticEnergy = m_settings.m_hCalToEMGeV * hit.getEnergy();
+
+        PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                                PandoraApi::CaloHit::Create(m_pandora, caloHitParameters))
+
+      } catch (const std::exception& e) {
+        m_algorithm.error() << "Exception processing HCAL hit: " << e.what() << endmsg;
       }
-
-      caloHitParameters.m_mipEquivalentEnergy = hit.getEnergy() * m_settings.m_hCalToMip * absorberCorrection;
-
-      if (caloHitParameters.m_mipEquivalentEnergy.Get() < m_settings.m_hCalMipThreshold)
-        continue;
-
-      caloHitParameters.m_hadronicEnergy =
-          std::min(m_settings.m_hCalToHadGeV * hit.getEnergy(), m_settings.m_maxHCalHitHadronicEnergy);
-      caloHitParameters.m_electromagneticEnergy = m_settings.m_hCalToEMGeV * hit.getEnergy();
-
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                              PandoraApi::CaloHit::Create(m_pandora, caloHitParameters))
-
-    } catch (const std::exception& e) {
-      m_algorithm.error() << "Exception processing HCAL hit: " << e.what() << endmsg;
     }
   }
 
@@ -260,15 +293,13 @@ DDCaloHitCreator::createHCalCaloHits(const std::vector<edm4hep::CalorimeterHit>&
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-pandora::StatusCode
-DDCaloHitCreator::createMuonCaloHits(const std::vector<edm4hep::CalorimeterHit>& muonCaloHits) const {
+pandora::StatusCode DDCaloHitCreator::createMuonCaloHits(const std::vector<CollectionDescriptor>& muonCaloHits) const {
 
   if (muonCaloHits.empty())
     return pandora::STATUS_CODE_SUCCESS;
 
   // Initialize BitFieldCoder with proper encoding string
   std::string initString = "system:5,side:2,module:8,stave:4,layer:9,submodule:4,x:32:-16,y:-16";
-  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
 
   const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& barrelLayers =
       getExtension((dd4hep::DetType::CALORIMETER | dd4hep::DetType::MUON | dd4hep::DetType::BARREL),
@@ -284,53 +315,70 @@ DDCaloHitCreator::createMuonCaloHits(const std::vector<edm4hep::CalorimeterHit>&
     return pandora::STATUS_CODE_FAILURE;
   }
 
-  for (const auto& hit : muonCaloHits) {
-    try {
-      PandoraApi::CaloHit::Parameters caloHitParameters;
-      caloHitParameters.m_hitType = pandora::MUON;
-      caloHitParameters.m_layer = bitFieldCoder.get(hit.getCellID(), "layer");
-      caloHitParameters.m_isInOuterSamplingLayer = true;
-      this->getCommonCaloHitProperties(hit, caloHitParameters);
-
-      const float radius =
-          std::sqrt(hit.getPosition()[0] * hit.getPosition()[0] + hit.getPosition()[1] * hit.getPosition()[1]);
-
-      const bool isWithinCoil = (radius < m_settings.m_coilOuterR);
-      const bool isInBarrelRegion = (std::fabs(hit.getPosition()[2]) < m_settings.m_muonBarrelOuterZ);
-
-      float absorberCorrection = 1.0;
-
-      if (isInBarrelRegion && isWithinCoil) {
-        m_algorithm.warning() << "BIG WARNING: CANNOT HANDLE PLUG HITS (no plug in CLIC model), DO NOTHING!" << endmsg;
-      } else if (isInBarrelRegion) {
-        this->getBarrelCaloHitProperties(hit, barrelLayers, m_settings.m_muonBarrelInnerSymmetry, caloHitParameters,
-                                         m_settings.m_muonBarrelNormalVector, absorberCorrection);
-      } else {
-        this->getEndCapCaloHitProperties(hit, endcapLayers, caloHitParameters, absorberCorrection);
-      }
-
-      if (m_settings.m_muonDigitalHits > 0) {
-        caloHitParameters.m_isDigital = true;
-        caloHitParameters.m_inputEnergy = m_settings.m_muonHitEnergy;
-        caloHitParameters.m_hadronicEnergy = m_settings.m_muonHitEnergy;
-        caloHitParameters.m_electromagneticEnergy = m_settings.m_muonHitEnergy;
-        caloHitParameters.m_mipEquivalentEnergy = 1.0f;
-      } else {
-        caloHitParameters.m_isDigital = false;
-        caloHitParameters.m_inputEnergy = hit.getEnergy();
-        caloHitParameters.m_hadronicEnergy = hit.getEnergy();
-        caloHitParameters.m_electromagneticEnergy = hit.getEnergy();
-        caloHitParameters.m_mipEquivalentEnergy = hit.getEnergy() * m_settings.m_muonToMip;
-      }
-
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                              PandoraApi::CaloHit::Create(m_pandora, caloHitParameters))
-
-    } catch (const std::exception& e) {
-      m_algorithm.error() << "Exception processing muon hit: " << e.what() << endmsg;
-    } catch (...) {
-      m_algorithm.error() << "Unknown exception processing muon hit. These can come from algorithms in LC Content."
+  for (const auto& hits : muonCaloHits) {
+    if (hits.collection->empty()) {
+      continue;
+    }
+    // AD: for ALLEGRO detector the above hardcoded cellID encoding does not work, so we need to extract it from the
+    // input collection
+    if (m_settings.m_detectorName == "ALLEGRO") {
+      initString = hits.cellIDEncoding;
+      if (initString.empty())
+        m_algorithm.error() << "Cannot get cellIDEncoding string for " << hits.collectionName << endmsg;
+      m_algorithm.debug() << "Extracted cellIDEncoding string for " << hits.collectionName << " : " << initString
                           << endmsg;
+    }
+    dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);
+
+    for (const auto& hit : *hits.collection) {
+      try {
+        PandoraApi::CaloHit::Parameters caloHitParameters;
+        caloHitParameters.m_hitType = pandora::MUON;
+        caloHitParameters.m_layer = bitFieldCoder.get(hit.getCellID(), "layer");
+        caloHitParameters.m_isInOuterSamplingLayer = true;
+        this->getCommonCaloHitProperties(hit, caloHitParameters);
+
+        const float radius =
+            std::sqrt(hit.getPosition()[0] * hit.getPosition()[0] + hit.getPosition()[1] * hit.getPosition()[1]);
+
+        const bool isWithinCoil = (radius < m_settings.m_coilOuterR);
+        const bool isInBarrelRegion = (std::fabs(hit.getPosition()[2]) < m_settings.m_muonBarrelOuterZ);
+
+        float absorberCorrection = 1.0;
+
+        if (isInBarrelRegion && isWithinCoil) {
+          m_algorithm.warning() << "BIG WARNING: CANNOT HANDLE PLUG HITS (no plug in CLIC model), DO NOTHING!"
+                                << endmsg;
+        } else if (isInBarrelRegion) {
+          this->getBarrelCaloHitProperties(hit, barrelLayers, m_settings.m_muonBarrelInnerSymmetry, caloHitParameters,
+                                           m_settings.m_muonBarrelNormalVector, absorberCorrection);
+        } else {
+          this->getEndCapCaloHitProperties(hit, endcapLayers, caloHitParameters, absorberCorrection);
+        }
+
+        if (m_settings.m_muonDigitalHits > 0) {
+          caloHitParameters.m_isDigital = true;
+          caloHitParameters.m_inputEnergy = m_settings.m_muonHitEnergy;
+          caloHitParameters.m_hadronicEnergy = m_settings.m_muonHitEnergy;
+          caloHitParameters.m_electromagneticEnergy = m_settings.m_muonHitEnergy;
+          caloHitParameters.m_mipEquivalentEnergy = 1.0f;
+        } else {
+          caloHitParameters.m_isDigital = false;
+          caloHitParameters.m_inputEnergy = hit.getEnergy();
+          caloHitParameters.m_hadronicEnergy = hit.getEnergy();
+          caloHitParameters.m_electromagneticEnergy = hit.getEnergy();
+          caloHitParameters.m_mipEquivalentEnergy = hit.getEnergy() * m_settings.m_muonToMip;
+        }
+
+        PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
+                                PandoraApi::CaloHit::Create(m_pandora, caloHitParameters))
+
+      } catch (const std::exception& e) {
+        m_algorithm.error() << "Exception processing muon hit: " << e.what() << endmsg;
+      } catch (...) {
+        m_algorithm.error() << "Unknown exception processing muon hit. These can come from algorithms in LC Content."
+                            << endmsg;
+      }
     }
   }
 

--- a/k4GaudiPandora/src/DDCaloHitCreatorALLEGRO.cc
+++ b/k4GaudiPandora/src/DDCaloHitCreatorALLEGRO.cc
@@ -17,30 +17,80 @@
  * limitations under the License.
  */
 
-/**
- *  @file   DDMarlinPandora/src/DDCaloHitCreator.cc
- *
- *  @brief  Implementation of the calo hit creator class.
- *
- *  $Log: $
- */
-
 #include "DDCaloHitCreatorALLEGRO.h"
-
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/DetType.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetectorSelector.h>
 #include <DDRec/DetectorData.h>
-
-// dd4hep::rec::LayeredCalorimeterData * getExtension(std::string detectorName);
-dd4hep::rec::LayeredCalorimeterData* getExtension(unsigned int includeFlag, unsigned int excludeFlag = 0);
 
 DDCaloHitCreatorALLEGRO::DDCaloHitCreatorALLEGRO(const Settings& settings, pandora::Pandora& pandora,
                                                  const Gaudi::Algorithm* algorithm)
-    : DDCaloHitCreator(settings, pandora, algorithm) {}
+    : DDCaloHitCreator(settings, pandora, algorithm), m_hcalBarrelSegmentation(nullptr),
+      m_hcalEndcapSegmentation(nullptr) {
 
-pandora::StatusCode DDCaloHitCreatorALLEGRO::createCaloHits(
-    const std::map<std::string, std::vector<edm4hep::CalorimeterHit>>& eCaloHitsMap,
-    const std::vector<edm4hep::CalorimeterHit>& hCalCaloHits, const std::vector<edm4hep::CalorimeterHit>& muonCaloHits,
-    const std::vector<edm4hep::CalorimeterHit>&, const std::vector<edm4hep::CalorimeterHit>&) const {
-  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createECalCaloHits(eCaloHitsMap))
+  dd4hep::Detector& mainDetector = dd4hep::Detector::getInstance();
+
+  const std::vector<dd4hep::DetElement>& hCalBarrelDetector =
+      dd4hep::DetectorSelector(mainDetector)
+          .detectors((dd4hep::DetType::CALORIMETER | dd4hep::DetType::HADRONIC | dd4hep::DetType::BARREL),
+                     (dd4hep::DetType::AUXILIARY | dd4hep::DetType::FORWARD));
+
+  const std::vector<dd4hep::DetElement>& hCalEndcapDetector =
+      dd4hep::DetectorSelector(mainDetector)
+          .detectors((dd4hep::DetType::CALORIMETER | dd4hep::DetType::HADRONIC | dd4hep::DetType::ENDCAP),
+                     (dd4hep::DetType::AUXILIARY | dd4hep::DetType::FORWARD));
+
+  auto hCalBarrelSensDet = mainDetector.sensitiveDetector(hCalBarrelDetector.at(0).name());
+  if (hCalBarrelSensDet.isValid()) {
+    auto readout = hCalBarrelSensDet.readout();
+    if (readout.isValid()) {
+      m_algorithm.debug() << "ALLEGRO DDCaloHitCreator: Readout: " << readout.name() << endmsg;
+      // get segmentation
+      dd4hep::DDSegmentation::Segmentation* aSegmentation = readout.segmentation().segmentation();
+      if (aSegmentation == nullptr) {
+        m_algorithm.error() << "ALLEGRO DDCaloHitCreator: Segmentation does not exist." << endmsg;
+      }
+
+      std::string segmentationType = aSegmentation->type();
+      m_algorithm.debug() << "ALLEGRO DDCaloHitCreator: Segmentation type : " << segmentationType << endmsg;
+      m_hcalBarrelSegmentation = std::shared_ptr<dd4hep::DDSegmentation::Segmentation>(
+          aSegmentation, [](dd4hep::DDSegmentation::Segmentation*) {});
+    }
+  }
+
+  auto hCalEndcapSensDet = mainDetector.sensitiveDetector(hCalEndcapDetector.at(0).name());
+  if (hCalEndcapSensDet.isValid()) {
+    auto readout = hCalEndcapSensDet.readout();
+    if (readout.isValid()) {
+      m_algorithm.debug() << "ALLEGRO DDCaloHitCreator: Readout: " << readout.name() << endmsg;
+      // get segmentation
+      dd4hep::DDSegmentation::Segmentation* aSegmentation = readout.segmentation().segmentation();
+      if (aSegmentation == nullptr) {
+        m_algorithm.error() << "ALLEGRO DDCaloHitCreator: Segmentation does not exist." << endmsg;
+      }
+
+      std::string segmentationType = aSegmentation->type();
+      m_algorithm.debug() << "ALLEGRO DDCaloHitCreator: Segmentation type : " << segmentationType << endmsg;
+      m_hcalEndcapSegmentation = std::shared_ptr<dd4hep::DDSegmentation::Segmentation>(
+          aSegmentation, [](dd4hep::DDSegmentation::Segmentation*) {});
+    }
+  }
+
+  // make sure that we have got readout segmentation objects
+  if (!m_hcalBarrelSegmentation || !m_hcalEndcapSegmentation) {
+    m_algorithm.error() << "ALLEGRO DDCaloHitCreator: Unable to get segmentation objects." << endmsg;
+    throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
+  }
+}
+
+pandora::StatusCode DDCaloHitCreatorALLEGRO::createCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits,
+                                                            const std::vector<CollectionDescriptor>& hCalCaloHits,
+                                                            const std::vector<CollectionDescriptor>& muonCaloHits,
+                                                            const std::vector<edm4hep::CalorimeterHit>&,
+                                                            const std::vector<edm4hep::CalorimeterHit>&) const {
+  PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createECalCaloHits(eCalCaloHits))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createHCalCaloHits(hCalCaloHits))
   PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, createMuonCaloHits(muonCaloHits))
 
@@ -52,12 +102,140 @@ void DDCaloHitCreatorALLEGRO::getCommonCaloHitProperties(const edm4hep::Calorime
   const auto position = hit.getPosition();
   const pandora::CartesianVector positionVector(position.x, position.y, position.z);
 
-  // FIXME! AD: for ECAL the cell gemoetry should be pandora::POINTING with cellSize0 = DeltaEta and cellSize1 =
-  // DeltaPhi
-  caloHitParameters.m_cellGeometry = pandora::RECTANGULAR;
+  // AD: HCAL cells are rectangular. If the hit is in the HCAL get the dimensions from the segmentation class
+  if (caloHitParameters.m_hitType.Get() == pandora::HCAL)
+    caloHitParameters.m_cellGeometry = pandora::RECTANGULAR;
+  else
+    caloHitParameters.m_cellGeometry = pandora::POINTING;
+
   caloHitParameters.m_positionVector = positionVector;
   caloHitParameters.m_expectedDirection = positionVector.GetUnitVector();
   caloHitParameters.m_pParentAddress = static_cast<const void*>(&hit);
   caloHitParameters.m_inputEnergy = hit.getEnergy();
   caloHitParameters.m_time = hit.getTime();
+}
+
+void DDCaloHitCreatorALLEGRO::getEndCapCaloHitProperties(
+    const edm4hep::CalorimeterHit& hit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+    PandoraApi::CaloHit::Parameters& caloHitParameters, float&) const {
+  caloHitParameters.m_hitRegion = pandora::ENDCAP;
+
+  m_algorithm.debug() << "ALLEGRO getEndCapCaloHitProperties:" << endmsg;
+  m_algorithm.debug() << "  Hit type: " << caloHitParameters.m_hitType.Get() << endmsg;
+  m_algorithm.debug() << "  Hit layer: " << caloHitParameters.m_layer.Get() << endmsg;
+  m_algorithm.debug() << "  Hit cellGeometry: " << caloHitParameters.m_cellGeometry.Get() << endmsg;
+
+  const int physicalLayer(
+      std::min(static_cast<int>(caloHitParameters.m_layer.Get()), static_cast<int>(layers.size() - 1)));
+
+  // AD: HCAL cells are rectangular. if the hit is in the HCAL get the dimensions from the segmentation class
+  if (caloHitParameters.m_hitType.Get() == pandora::HCAL) {
+    std::vector<double> cellSize = m_hcalEndcapSegmentation->cellDimensions(hit.getCellID());
+    caloHitParameters.m_cellSize0 = cellSize[0] / dd4hep::mm;
+    caloHitParameters.m_cellSize1 = cellSize[1] / dd4hep::mm;
+  } else {
+    caloHitParameters.m_cellSize0 = layers[physicalLayer].cellSize0;
+    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1;
+  }
+
+  m_algorithm.debug() << "  Hit cellSize0: " << caloHitParameters.m_cellSize0.Get() << endmsg;
+  m_algorithm.debug() << "  Hit cellSize1: " << caloHitParameters.m_cellSize1.Get() << endmsg;
+  m_algorithm.debug() << "  Nlayers: " << layers.size() << endmsg;
+
+  double thickness =
+      (layers[physicalLayer].inner_thickness + layers[physicalLayer].sensitive_thickness / 2.0) / dd4hep::mm;
+  double nRadLengths = layers[physicalLayer].inner_nRadiationLengths;
+  double nIntLengths = layers[physicalLayer].inner_nInteractionLengths;
+
+  if (physicalLayer > 0) {
+    thickness +=
+        (layers[physicalLayer - 1].outer_thickness - layers[physicalLayer].sensitive_thickness / 2.0) / dd4hep::mm;
+    nRadLengths += layers[physicalLayer - 1].outer_nRadiationLengths;
+    nIntLengths += layers[physicalLayer - 1].outer_nInteractionLengths;
+  }
+
+  caloHitParameters.m_cellThickness = thickness;
+  caloHitParameters.m_nCellRadiationLengths = nRadLengths;
+  caloHitParameters.m_nCellInteractionLengths = nIntLengths;
+
+  if (caloHitParameters.m_nCellRadiationLengths.Get() < std::numeric_limits<float>::epsilon() ||
+      caloHitParameters.m_nCellInteractionLengths.Get() < std::numeric_limits<float>::epsilon()) {
+    m_algorithm.warning()
+        << "ALLEGRO CaloHitCreator::getEndCapCaloHitProperties Calo hit has 0 radiation length or interaction length: \
+            not creating a Pandora calo hit."
+        << endmsg;
+    throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
+  }
+  caloHitParameters.m_cellNormalVector =
+      (hit.getPosition()[2] > 0) ? pandora::CartesianVector(0, 0, 1) : pandora::CartesianVector(0, 0, -1);
+
+  m_algorithm.debug() << "ALLEGRO getEndCapCaloHitProperties: physLayer: " << physicalLayer
+                      << " layer: " << caloHitParameters.m_layer.Get()
+                      << " nX0: " << caloHitParameters.m_nCellRadiationLengths.Get()
+                      << " nLambdaI: " << caloHitParameters.m_nCellInteractionLengths.Get()
+                      << " thickness: " << caloHitParameters.m_cellThickness.Get() << endmsg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void DDCaloHitCreatorALLEGRO::getBarrelCaloHitProperties(
+    const edm4hep::CalorimeterHit& hit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
+    unsigned int, PandoraApi::CaloHit::Parameters& caloHitParameters, FloatVector const&, float&) const {
+  caloHitParameters.m_hitRegion = pandora::BARREL;
+
+  m_algorithm.debug() << "ALLEGRO getBarrelCaloHitProperties:" << endmsg;
+  m_algorithm.debug() << "  Hit type: " << caloHitParameters.m_hitType.Get() << endmsg;
+  m_algorithm.debug() << "  Hit layer: " << caloHitParameters.m_layer.Get() << endmsg;
+  m_algorithm.debug() << "  Hit cellGeometry: " << caloHitParameters.m_cellGeometry.Get() << endmsg;
+
+  const int physicalLayer(
+      std::min(static_cast<int>(caloHitParameters.m_layer.Get()), static_cast<int>(layers.size() - 1)));
+
+  // AD: HCAL cells are rectangular. If the hit is in the HCAL get dimensions from the segmentation class
+  if (caloHitParameters.m_hitType.Get() == pandora::HCAL) {
+    std::vector<double> cellSize = m_hcalBarrelSegmentation->cellDimensions(hit.getCellID());
+    caloHitParameters.m_cellSize0 = cellSize[0] / dd4hep::mm;
+    caloHitParameters.m_cellSize1 = cellSize[1] / dd4hep::mm;
+  } else {
+    caloHitParameters.m_cellSize0 = layers[physicalLayer].cellSize0;
+    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1;
+  }
+
+  m_algorithm.debug() << "  Hit cellSize0: " << caloHitParameters.m_cellSize0.Get() << endmsg;
+  m_algorithm.debug() << "  Hit cellSize1: " << caloHitParameters.m_cellSize1.Get() << endmsg;
+  m_algorithm.debug() << "  Nlayers: " << layers.size() << endmsg;
+
+  double thickness =
+      (layers[physicalLayer].inner_thickness + layers[physicalLayer].sensitive_thickness / 2.0) / dd4hep::mm;
+  double nRadLengths = layers[physicalLayer].inner_nRadiationLengths;
+  double nIntLengths = layers[physicalLayer].inner_nInteractionLengths;
+
+  if (physicalLayer > 0) {
+    thickness +=
+        (layers[physicalLayer - 1].outer_thickness - layers[physicalLayer].sensitive_thickness / 2.0) / dd4hep::mm;
+    nRadLengths += layers[physicalLayer - 1].outer_nRadiationLengths;
+    nIntLengths += layers[physicalLayer - 1].outer_nInteractionLengths;
+  }
+
+  caloHitParameters.m_cellThickness = thickness;
+  caloHitParameters.m_nCellRadiationLengths = nRadLengths;
+  caloHitParameters.m_nCellInteractionLengths = nIntLengths;
+
+  if (caloHitParameters.m_nCellRadiationLengths.Get() < std::numeric_limits<float>::epsilon() ||
+      caloHitParameters.m_nCellInteractionLengths.Get() < std::numeric_limits<float>::epsilon()) {
+    m_algorithm.warning()
+        << "ALLEGRO CaloHitCreator::getBarrelCaloHitProperties Calo hit has 0 radiation length or interaction length: \
+            not creating a Pandora calo hit."
+        << endmsg;
+    throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
+  }
+
+  const auto position(hit.getPosition());
+  const float phi = std::atan2(position.y, position.y);
+  caloHitParameters.m_cellNormalVector = pandora::CartesianVector(std::cos(phi), std::sin(phi), 0);
+
+  m_algorithm.debug() << "ALLEGRO getBarrelCaloHitProperties: physLayer: " << physicalLayer
+                      << " layer: " << caloHitParameters.m_layer.Get()
+                      << " nX0: " << caloHitParameters.m_nCellRadiationLengths.Get()
+                      << " nLambdaI: " << caloHitParameters.m_nCellInteractionLengths.Get()
+                      << " thickness: " << caloHitParameters.m_cellThickness.Get() << endmsg;
 }

--- a/k4GaudiPandora/src/DDCaloHitCreatorALLEGRO.cc
+++ b/k4GaudiPandora/src/DDCaloHitCreatorALLEGRO.cc
@@ -85,6 +85,7 @@ DDCaloHitCreatorALLEGRO::DDCaloHitCreatorALLEGRO(const Settings& settings, pando
   }
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
 pandora::StatusCode DDCaloHitCreatorALLEGRO::createCaloHits(const std::vector<CollectionDescriptor>& eCalCaloHits,
                                                             const std::vector<CollectionDescriptor>& hCalCaloHits,
                                                             const std::vector<CollectionDescriptor>& muonCaloHits,
@@ -97,6 +98,7 @@ pandora::StatusCode DDCaloHitCreatorALLEGRO::createCaloHits(const std::vector<Co
   return pandora::STATUS_CODE_SUCCESS;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
 void DDCaloHitCreatorALLEGRO::getCommonCaloHitProperties(const edm4hep::CalorimeterHit& hit,
                                                          PandoraApi::CaloHit::Parameters& caloHitParameters) const {
   const auto position = hit.getPosition();
@@ -106,6 +108,7 @@ void DDCaloHitCreatorALLEGRO::getCommonCaloHitProperties(const edm4hep::Calorime
   if (caloHitParameters.m_hitType.Get() == pandora::HCAL)
     caloHitParameters.m_cellGeometry = pandora::RECTANGULAR;
   else
+    // NOTE: pandora::POINTING assumes a DeltaEta segmentation
     caloHitParameters.m_cellGeometry = pandora::POINTING;
 
   caloHitParameters.m_positionVector = positionVector;
@@ -115,6 +118,7 @@ void DDCaloHitCreatorALLEGRO::getCommonCaloHitProperties(const edm4hep::Calorime
   caloHitParameters.m_time = hit.getTime();
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
 void DDCaloHitCreatorALLEGRO::getEndCapCaloHitProperties(
     const edm4hep::CalorimeterHit& hit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers,
     PandoraApi::CaloHit::Parameters& caloHitParameters, float&) const {
@@ -134,8 +138,14 @@ void DDCaloHitCreatorALLEGRO::getEndCapCaloHitProperties(
     caloHitParameters.m_cellSize0 = cellSize[0] / dd4hep::mm;
     caloHitParameters.m_cellSize1 = cellSize[1] / dd4hep::mm;
   } else {
-    caloHitParameters.m_cellSize0 = layers[physicalLayer].cellSize0;
-    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1;
+    edm4hep::Vector3f position = hit.getPosition();
+    double deltaTheta = layers[physicalLayer].cellSize0;
+    double r = std::sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
+    double theta = std::acos(position.z / r);
+    caloHitParameters.m_cellSize0 = this->convertDeltaThetaToDeltaEta(deltaTheta, theta);
+    // NOTE: need to multiply the cellSize1 by sin(theta) because of known issue in the PandoraSDK implementation of POINTING cells:
+    // https://github.com/PandoraPFA/PandoraSDK/issues/22
+    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1 * std::sin(theta);
   }
 
   m_algorithm.debug() << "  Hit cellSize0: " << caloHitParameters.m_cellSize0.Get() << endmsg;
@@ -196,8 +206,14 @@ void DDCaloHitCreatorALLEGRO::getBarrelCaloHitProperties(
     caloHitParameters.m_cellSize0 = cellSize[0] / dd4hep::mm;
     caloHitParameters.m_cellSize1 = cellSize[1] / dd4hep::mm;
   } else {
-    caloHitParameters.m_cellSize0 = layers[physicalLayer].cellSize0;
-    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1;
+    edm4hep::Vector3f position = hit.getPosition();
+    double deltaTheta = layers[physicalLayer].cellSize0;
+    double r = std::sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
+    double theta = std::acos(position.z / r);
+    caloHitParameters.m_cellSize0 = this->convertDeltaThetaToDeltaEta(deltaTheta, theta);
+    // NOTE: need to multiply the cellSize1 by sin(theta) because of known issue in the PandoraSDK implementation of POINTING cells:
+    // https://github.com/PandoraPFA/PandoraSDK/issues/22
+    caloHitParameters.m_cellSize1 = layers[physicalLayer].cellSize1 * std::sin(theta);
   }
 
   m_algorithm.debug() << "  Hit cellSize0: " << caloHitParameters.m_cellSize0.Get() << endmsg;
@@ -238,4 +254,14 @@ void DDCaloHitCreatorALLEGRO::getBarrelCaloHitProperties(
                       << " nX0: " << caloHitParameters.m_nCellRadiationLengths.Get()
                       << " nLambdaI: " << caloHitParameters.m_nCellInteractionLengths.Get()
                       << " thickness: " << caloHitParameters.m_cellThickness.Get() << endmsg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+double DDCaloHitCreatorALLEGRO::convertDeltaThetaToDeltaEta(double deltaTheta, double theta) const {
+  double thetaLow = theta - deltaTheta / 2.0;
+  double thetaHigh = theta + deltaTheta / 2.0;
+  double etaLow = -std::log(std::tan(thetaLow / 2.0));
+  double etaHigh = -std::log(std::tan(thetaHigh / 2.0));
+
+  return std::abs(etaHigh - etaLow);
 }

--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -43,6 +43,7 @@
 #include <DD4hep/Detector.h>
 #include <DD4hep/DetectorSelector.h>
 #include <DDRec/DetectorData.h>
+#include <k4FWCore/MetadataUtils.h>
 
 #include <cstdlib>
 #include <sstream>
@@ -195,6 +196,7 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
     //                         m_pDDMCParticleCreator->CreateTrackToMCParticleRelationships(
     //                             trackerHitLinkCollections, m_pTrackCreator->GetTrackVector(), trackCollections))
 
+    std::vector<CollectionDescriptor> eCalHitCollections;
     std::map<std::string, std::vector<edm4hep::CalorimeterHit>> eCalHitCollectionsMap;
     const auto eCalHitCollectionsNames = inputLocations("ECalCaloHitCollections");
     for (size_t i = 0; i < eCalHitCollectionsNames.size(); ++i) {
@@ -202,18 +204,46 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
       eCalHitCollectionsMap[eCalHitCollectionsNames[i]].reserve(eCalCollection->size());
       eCalHitCollectionsMap[eCalHitCollectionsNames[i]].insert(eCalHitCollectionsMap[eCalHitCollectionsNames[i]].end(),
                                                                eCalCollection->begin(), eCalCollection->end());
+      auto hitsEncoding = k4FWCore::getCellIDEncoding(std::string(eCalHitCollectionsNames[i]), this);
+      eCalHitCollections.emplace_back(
+          CollectionDescriptor{.collectionName = eCalHitCollectionsNames[i],
+                               .cellIDEncoding = (hitsEncoding.has_value()) ? hitsEncoding.value() : "",
+                               .collection = &eCalHitCollectionsMap[eCalHitCollectionsNames[i]]});
     }
-    std::vector<edm4hep::CalorimeterHit> hCalHitCollectionsVector;
-    std::vector<edm4hep::CalorimeterHit> mCalHitCollectionsVector;
+
+    std::vector<CollectionDescriptor> hCalHitCollections;
+    std::map<std::string, std::vector<edm4hep::CalorimeterHit>> hCalHitCollectionsMap;
+    const auto hCalHitCollectionsNames = inputLocations("HCalCaloHitCollections");
+    for (size_t i = 0; i < hCalHitCollectionsNames.size(); ++i) {
+      const auto& hCalCollection = hCalCollections[i];
+      hCalHitCollectionsMap[hCalHitCollectionsNames[i]].reserve(hCalCollection->size());
+      hCalHitCollectionsMap[hCalHitCollectionsNames[i]].insert(hCalHitCollectionsMap[hCalHitCollectionsNames[i]].end(),
+                                                               hCalCollection->begin(), hCalCollection->end());
+      auto hitsEncoding = k4FWCore::getCellIDEncoding(std::string(hCalHitCollectionsNames[i]), this);
+      hCalHitCollections.emplace_back(
+          CollectionDescriptor{.collectionName = hCalHitCollectionsNames[i],
+                               .cellIDEncoding = (hitsEncoding.has_value()) ? hitsEncoding.value() : "",
+                               .collection = &hCalHitCollectionsMap[hCalHitCollectionsNames[i]]});
+    }
+
+    std::vector<CollectionDescriptor> mCalHitCollections;
+    std::map<std::string, std::vector<edm4hep::CalorimeterHit>> mCalHitCollectionsMap;
+    const auto mCalHitCollectionsNames = inputLocations("MuonCaloHitCollections");
+    for (size_t i = 0; i < mCalHitCollectionsNames.size(); ++i) {
+      const auto& mCalCollection = mCalCollections[i];
+      mCalHitCollectionsMap[mCalHitCollectionsNames[i]].reserve(mCalCollection->size());
+      mCalHitCollectionsMap[mCalHitCollectionsNames[i]].insert(mCalHitCollectionsMap[mCalHitCollectionsNames[i]].end(),
+                                                               mCalCollection->begin(), mCalCollection->end());
+      auto hitsEncoding = k4FWCore::getCellIDEncoding(std::string(mCalHitCollectionsNames[i]), this);
+      mCalHitCollections.emplace_back(
+          CollectionDescriptor{.collectionName = mCalHitCollectionsNames[i],
+                               .cellIDEncoding = (hitsEncoding.has_value()) ? hitsEncoding.value() : "",
+                               .collection = &mCalHitCollectionsMap[mCalHitCollectionsNames[i]]});
+    }
+
     std::vector<edm4hep::CalorimeterHit> lCalHitCollectionsVector;
     std::vector<edm4hep::CalorimeterHit> lhCalHitCollectionsVector;
 
-    hCalHitCollectionsVector.reserve(
-        std::accumulate(hCalCollections.begin(), hCalCollections.end(), size_t(0),
-                        [](size_t sum, const edm4hep::CalorimeterHitCollection* col) { return sum + col->size(); }));
-    mCalHitCollectionsVector.reserve(
-        std::accumulate(mCalCollections.begin(), mCalCollections.end(), size_t(0),
-                        [](size_t sum, const edm4hep::CalorimeterHitCollection* col) { return sum + col->size(); }));
     lCalHitCollectionsVector.reserve(
         std::accumulate(lCalCollections.begin(), lCalCollections.end(), size_t(0),
                         [](size_t sum, const edm4hep::CalorimeterHitCollection* col) { return sum + col->size(); }));
@@ -221,12 +251,6 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
         std::accumulate(lhCalCollections.begin(), lhCalCollections.end(), size_t(0),
                         [](size_t sum, const edm4hep::CalorimeterHitCollection* col) { return sum + col->size(); }));
 
-    for (const auto& hCalCollection : hCalCollections) {
-      hCalHitCollectionsVector.insert(hCalHitCollectionsVector.end(), hCalCollection->begin(), hCalCollection->end());
-    }
-    for (const auto& mCalCollection : mCalCollections) {
-      mCalHitCollectionsVector.insert(mCalHitCollectionsVector.end(), mCalCollection->begin(), mCalCollection->end());
-    }
     for (const auto& lCalCollection : lCalCollections) {
       lCalHitCollectionsVector.insert(lCalHitCollectionsVector.end(), lCalCollection->begin(), lCalCollection->end());
     }
@@ -236,9 +260,8 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
     }
 
     PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                            m_caloHitCreator->createCaloHits(eCalHitCollectionsMap, hCalHitCollectionsVector,
-                                                             mCalHitCollectionsVector, lCalHitCollectionsVector,
-                                                             lhCalHitCollectionsVector))
+                            m_caloHitCreator->createCaloHits(eCalHitCollections, hCalHitCollections, mCalHitCollections,
+                                                             lCalHitCollectionsVector, lhCalHitCollectionsVector))
 
     // PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
     //                         m_pDDMCParticleCreator->CreateCaloHitToMCParticleRelationships(
@@ -440,8 +463,22 @@ void DDPandoraPFANewAlgorithm::finaliseSteeringParameters() {
   //  const dd4hep::rec::LayeredCalorimeterData * muonEndcapExtension= getExtension( ( dd4hep::DetType::CALORIMETER |
   //  dd4hep::DetType::MUON | dd4hep::DetType::ENDCAP),  log, ( dd4hep::DetType::AUXILIARY ) );
 
-  // Get COIL extension
-  const dd4hep::rec::LayeredCalorimeterData* coilExtension = getExtension((dd4hep::DetType::COIL));
+  if (m_settings.m_detectorName != "ALLEGRO") {
+    // Get COIL extension
+    const dd4hep::rec::LayeredCalorimeterData* coilExtension = getExtension((dd4hep::DetType::COIL));
+    m_caloHitCreatorSettings.m_coilOuterR = coilExtension->extent[1] / dd4hep::mm;
+  } else {
+    // ALLEGRO does not have a coil extension (no COIL volume simulated yet)
+    // so the solenoid outer radius is set here to be equal as the inner radius
+    // of the HCAL barrel (the solenoid is in the ECAL cryostat, between ECAL and HCAL)
+    m_caloHitCreatorSettings.m_coilOuterR = hCalBarrelExtension->extent[0] / dd4hep::mm;
+    // More ALLEGRO-specific settings
+    m_caloHitCreatorSettings.m_useSystemId = true;
+    m_caloHitCreatorSettings.m_ecalBarrelSystemId = 4;
+    m_caloHitCreatorSettings.m_hcalBarrelSystemId = 8;
+    m_caloHitCreatorSettings.m_hcalEndcapSystemId = 9;
+    m_caloHitCreatorSettings.m_detectorName = m_settings.m_detectorName;
+  }
 
   m_trackCreatorSettings.m_eCalBarrelInnerSymmetry = eCalBarrelExtension->inner_symmetry;
   m_trackCreatorSettings.m_eCalBarrelInnerPhi0 = eCalBarrelExtension->inner_phi0 / dd4hep::rad;
@@ -451,7 +488,6 @@ void DDPandoraPFANewAlgorithm::finaliseSteeringParameters() {
   m_caloHitCreatorSettings.m_eCalBarrelOuterZ = eCalBarrelExtension->extent[3] / dd4hep::mm;
   m_caloHitCreatorSettings.m_hCalBarrelOuterZ = hCalBarrelExtension->extent[3] / dd4hep::mm;
   m_caloHitCreatorSettings.m_muonBarrelOuterZ = muonBarrelExtension->extent[3] / dd4hep::mm;
-  m_caloHitCreatorSettings.m_coilOuterR = coilExtension->extent[1] / dd4hep::mm;
   m_caloHitCreatorSettings.m_eCalBarrelInnerPhi0 = eCalBarrelExtension->inner_phi0 / dd4hep::rad;
   m_caloHitCreatorSettings.m_eCalBarrelInnerSymmetry = eCalBarrelExtension->inner_symmetry;
   m_caloHitCreatorSettings.m_hCalBarrelInnerPhi0 = hCalBarrelExtension->inner_phi0 / dd4hep::rad;

--- a/k4GaudiPandora/src/DDTrackCreatorALLEGRO.cc
+++ b/k4GaudiPandora/src/DDTrackCreatorALLEGRO.cc
@@ -303,7 +303,7 @@ void DDTrackCreatorALLEGRO::DefineTrackPfoUsage(const edm4hep::Track& pTrack,
 
 void DDTrackCreatorALLEGRO::TrackReachesECAL(const edm4hep::Track& pTrack,
                                              PandoraApi::Track::Parameters& trackParameters) const {
-  // FIXME! AD: since currently we have do not have track hits -> check the radius of the trackState AtCalo.
+  // FIXME! AD: since currently we do not have track hits -> check the radius of the trackState AtCalo.
   // currently check is done only for ECAL barrel but should check if track reaches the Endcap!
   pandora::CartesianVector posAtCalo(trackParameters.m_trackStateAtCalorimeter.Get().GetPosition());
   double radiusAtCalo = std::sqrt(posAtCalo.GetX() * posAtCalo.GetX() + posAtCalo.GetY() * posAtCalo.GetY());


### PR DESCRIPTION
BEGINRELEASENOTES
- Hit collections are now passed to DDCaloHitCreator with attached cellIDEncoding string. This enables to use the bitFieldCoder for ALLEGRO detector that has very different cellID encoding strings compared to the hard-coded value of initString. 
- Changes are implemented to enable running the PandoraPFA on ALLEGRO simulation.

ENDRELEASENOTES
