### PR TITLE
Add K4GAUDIPANDORA_USE_DDKALTEST flag to switch between legacy code and pre-computed extrapolations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,9 @@ option(K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
 if(NOT K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS AND NOT TARGET k4Reco::GaudiTrkUtils)
   message(FATAL_ERROR
     "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
-    "BUILD_TRACKING=ON (spack: k4reco+conformal_tracking) and pulls in LCIO, KalTest "
-    "and DDKalTest.\n"
+    "BUILD_TRACKING=ON.\n"
     "To build against a stack without LCIO, configure with "
-    "-DK4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS=ON. The track state at the calorimeter "
-    "is then read directly from the input EDM, which requires the tracks to have been "
-    "produced by k4ActsTracking's CKFTrackingAlg with ExtrapolateToCalo=True.")
+    "-DK4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS=ON.")
 endif()
 
 message(STATUS "K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS: ${K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,22 +43,21 @@ find_package(k4Reco)
 
 #---------------------------------------------------------------
 
-# Whether to extrapolate to the calorimeter internally, using DDKalTest through
-# k4Reco::GaudiTrkUtils:
+# Selects where the track states at the calorimeter faces that pandora needs are
+# computed:
 #
-#  - ON (default): for tracks whose track state at the calorimeter is in the
-#    barrel, the track is re-propagated to the ECal endcap face and the result is
-#    appended as an additional track state, so that pandora can try both. This is
-#    the legacy DDMarlinPandora behaviour, and it pulls in LCIO, KalTest and
+#  - ON (default): here, with DDKalTest. For tracks whose track state at the
+#    calorimeter is in the barrel, the extrapolation to the ECal endcap face is
+#    recomputed and passed on as an additional track state, so that pandora can
+#    consider both. This uses k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and
 #    DDKalTest.
 #
-#  - OFF: only the track states already present in the input EDM are used, and
-#    k4Reco::GaudiTrkUtils is not needed. Whether that is enough depends on what
-#    produced the tracks: it requires the extrapolation to the calorimeter to have
-#    been done upstream, as k4ActsTracking's CKFTrackingAlg does with
-#    ExtrapolateToCalo=True.
+#  - OFF: upstream. The input tracks already carry the track states at the
+#    calorimeter, as those from k4ActsTracking's CKFTrackingAlg with
+#    ExtrapolateToCalo=True do, so nothing is recomputed here and
+#    k4Reco::GaudiTrkUtils is not needed.
 option(K4GAUDIPANDORA_USE_DDKALTEST
-       "Extrapolate tracks to the calorimeter face internally with DDKalTest, adding a track state at the ECal endcap on top of the ones present in the input EDM. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest."
+       "Recompute the extrapolation to the ECal endcap face with DDKalTest, to give pandora an additional track state at the calorimeter. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest. When OFF, the track states at the calorimeter are expected to be already present on the input tracks and are forwarded as they are."
        ON)
 
 if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
@@ -66,8 +65,8 @@ if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
     "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
     "BUILD_TRACKING=ON.\n"
     "To build against a stack without LCIO, configure with "
-    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. The track states are then taken from the "
-    "input EDM as they are.")
+    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. Nothing is then recomputed here, and the "
+    "track states at the calorimeter must already be present on the input tracks.")
 endif()
 
 message(STATUS "K4GAUDIPANDORA_USE_DDKALTEST: ${K4GAUDIPANDORA_USE_DDKALTEST}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,37 +43,34 @@ find_package(k4Reco)
 
 #---------------------------------------------------------------
 
-# The track state at the calorimeter face can come from two places:
+# Whether to extrapolate to the calorimeter internally, using DDKalTest through
+# k4Reco::GaudiTrkUtils:
 #
-#  - OFF (default): the legacy pipeline. k4Reco::GaudiTrkUtils re-propagates the
-#    track with DDKalTest to the ECal endcap face and an alternative track state
-#    is appended, so that Pandora can try both it and the one already stored in
-#    the EDM. This exists because GaudiTrkUtils::createTrackStateAtCaloFace does
-#    not navigate to the calorimeter: it propagates to the ECal barrel and to
-#    the ECal endcap and then keeps whichever intersection is closest to the
-#    last tracker hit, which picks the wrong face in the barrel/endcap
-#    transition region. It pulls in LCIO, KalTest and DDKalTest.
+#  - ON (default): for tracks whose track state at the calorimeter is in the
+#    barrel, the track is re-propagated to the ECal endcap face and the result is
+#    appended as an additional track state, so that pandora can try both. This is
+#    the legacy DDMarlinPandora behaviour, and it pulls in LCIO, KalTest and
+#    DDKalTest.
 #
-#  - ON: the track state stored in the EDM is used as is. k4ActsTracking's
-#    CKFTrackingAlg (ExtrapolateToCalo=True) obtains it by propagating with an
-#    Acts::Navigator over the calorimeter face surfaces, so the face is resolved
-#    by navigation rather than guessed and the alternative state is redundant.
-#
-# Note that this does not add a build dependency on k4ActsTracking; it is a
-# statement about the input data, not about what we link against.
-option(K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
-       "Take the track state at the calorimeter from the input EDM instead of re-propagating it with DDKalTest. Requires input tracks produced by k4ActsTracking's CKFTrackingAlg with ExtrapolateToCalo=True, and drops the dependency on k4Reco::GaudiTrkUtils (and hence on LCIO, KalTest and DDKalTest)."
-       OFF)
+#  - OFF: only the track states already present in the input EDM are used, and
+#    k4Reco::GaudiTrkUtils is not needed. Whether that is enough depends on what
+#    produced the tracks: it requires the extrapolation to the calorimeter to have
+#    been done upstream, as k4ActsTracking's CKFTrackingAlg does with
+#    ExtrapolateToCalo=True.
+option(K4GAUDIPANDORA_USE_DDKALTEST
+       "Extrapolate tracks to the calorimeter face internally with DDKalTest, adding a track state at the ECal endcap on top of the ones present in the input EDM. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest."
+       ON)
 
-if(NOT K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS AND NOT TARGET k4Reco::GaudiTrkUtils)
+if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
   message(FATAL_ERROR
     "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
     "BUILD_TRACKING=ON.\n"
     "To build against a stack without LCIO, configure with "
-    "-DK4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS=ON.")
+    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. The track states are then taken from the "
+    "input EDM as they are.")
 endif()
 
-message(STATUS "K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS: ${K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS}")
+message(STATUS "K4GAUDIPANDORA_USE_DDKALTEST: ${K4GAUDIPANDORA_USE_DDKALTEST}")
 
 #---------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,20 +42,6 @@ find_package(Gaudi)
 find_package(k4Reco)
 
 #---------------------------------------------------------------
-
-# Selects where the track states at the calorimeter faces that pandora needs are
-# computed:
-#
-#  - ON (default): here, with DDKalTest. For tracks whose track state at the
-#    calorimeter is in the barrel, the extrapolation to the ECal endcap face is
-#    recomputed and passed on as an additional track state, so that pandora can
-#    consider both. This uses k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and
-#    DDKalTest.
-#
-#  - OFF: upstream. The input tracks already carry the track states at the
-#    calorimeter, as those from k4ActsTracking's CKFTrackingAlg with
-#    ExtrapolateToCalo=True do, so nothing is recomputed here: all of them are
-#    passed on and k4Reco::GaudiTrkUtils is not needed.
 option(K4GAUDIPANDORA_USE_DDKALTEST
        "Recompute the extrapolation to the ECal endcap face with DDKalTest, to give pandora an additional track state at the calorimeter. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest. When OFF, the track states at the calorimeter are expected to be already present on the input tracks, and all of them are passed on."
        ON)
@@ -65,8 +51,7 @@ if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
     "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
     "BUILD_TRACKING=ON.\n"
     "To build against a stack without LCIO, configure with "
-    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. Nothing is then recomputed here, and the track "
-    "states at the calorimeter must already be present on the input tracks.")
+    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF.")
 endif()
 
 message(STATUS "K4GAUDIPANDORA_USE_DDKALTEST: ${K4GAUDIPANDORA_USE_DDKALTEST}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,43 @@ find_package(k4Reco)
 
 #---------------------------------------------------------------
 
+# The track state at the calorimeter face can come from two places:
+#
+#  - OFF (default): the legacy pipeline. k4Reco::GaudiTrkUtils re-propagates the
+#    track with DDKalTest to the ECal endcap face and an alternative track state
+#    is appended, so that Pandora can try both it and the one already stored in
+#    the EDM. This exists because GaudiTrkUtils::createTrackStateAtCaloFace does
+#    not navigate to the calorimeter: it propagates to the ECal barrel and to
+#    the ECal endcap and then keeps whichever intersection is closest to the
+#    last tracker hit, which picks the wrong face in the barrel/endcap
+#    transition region. It pulls in LCIO, KalTest and DDKalTest.
+#
+#  - ON: the track state stored in the EDM is used as is. k4ActsTracking's
+#    CKFTrackingAlg (ExtrapolateToCalo=True) obtains it by propagating with an
+#    Acts::Navigator over the calorimeter face surfaces, so the face is resolved
+#    by navigation rather than guessed and the alternative state is redundant.
+#
+# Note that this does not add a build dependency on k4ActsTracking; it is a
+# statement about the input data, not about what we link against.
+option(K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+       "Take the track state at the calorimeter from the input EDM instead of re-propagating it with DDKalTest. Requires input tracks produced by k4ActsTracking's CKFTrackingAlg with ExtrapolateToCalo=True, and drops the dependency on k4Reco::GaudiTrkUtils (and hence on LCIO, KalTest and DDKalTest)."
+       OFF)
+
+if(NOT K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS AND NOT TARGET k4Reco::GaudiTrkUtils)
+  message(FATAL_ERROR
+    "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
+    "BUILD_TRACKING=ON (spack: k4reco+conformal_tracking) and pulls in LCIO, KalTest "
+    "and DDKalTest.\n"
+    "To build against a stack without LCIO, configure with "
+    "-DK4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS=ON. The track state at the calorimeter "
+    "is then read directly from the input EDM, which requires the tracks to have been "
+    "produced by k4ActsTracking's CKFTrackingAlg with ExtrapolateToCalo=True.")
+endif()
+
+message(STATUS "K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS: ${K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS}")
+
+#---------------------------------------------------------------
+
 include(cmake/Key4hepConfig.cmake)
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,10 @@ find_package(k4Reco)
 #
 #  - OFF: upstream. The input tracks already carry the track states at the
 #    calorimeter, as those from k4ActsTracking's CKFTrackingAlg with
-#    ExtrapolateToCalo=True do, so nothing is recomputed here and
-#    k4Reco::GaudiTrkUtils is not needed.
+#    ExtrapolateToCalo=True do, so nothing is recomputed here: all of them are
+#    passed on and k4Reco::GaudiTrkUtils is not needed.
 option(K4GAUDIPANDORA_USE_DDKALTEST
-       "Recompute the extrapolation to the ECal endcap face with DDKalTest, to give pandora an additional track state at the calorimeter. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest. When OFF, the track states at the calorimeter are expected to be already present on the input tracks and are forwarded as they are."
+       "Recompute the extrapolation to the ECal endcap face with DDKalTest, to give pandora an additional track state at the calorimeter. Requires k4Reco::GaudiTrkUtils, and hence LCIO, KalTest and DDKalTest. When OFF, the track states at the calorimeter are expected to be already present on the input tracks, and all of them are passed on."
        ON)
 
 if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
@@ -65,8 +65,8 @@ if(K4GAUDIPANDORA_USE_DDKALTEST AND NOT TARGET k4Reco::GaudiTrkUtils)
     "k4Reco::GaudiTrkUtils was not found. It is provided by k4Reco built with "
     "BUILD_TRACKING=ON.\n"
     "To build against a stack without LCIO, configure with "
-    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. Nothing is then recomputed here, and the "
-    "track states at the calorimeter must already be present on the input tracks.")
+    "-DK4GAUDIPANDORA_USE_DDKALTEST=OFF. Nothing is then recomputed here, and the track "
+    "states at the calorimeter must already be present on the input tracks.")
 endif()
 
 message(STATUS "K4GAUDIPANDORA_USE_DDKALTEST: ${K4GAUDIPANDORA_USE_DDKALTEST}")

--- a/k4GaudiPandora/CMakeLists.txt
+++ b/k4GaudiPandora/CMakeLists.txt
@@ -52,9 +52,8 @@ gaudi_add_module(k4GaudiPandoraPlugins
                       ${PandoraSDK_LIBRARIES}
                       ${LCContent_LIBRARIES}
                     )
-if(K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS)
-  target_compile_definitions(k4GaudiPandoraPlugins PRIVATE K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS)
-else()
+if(K4GAUDIPANDORA_USE_DDKALTEST)
+  target_compile_definitions(k4GaudiPandoraPlugins PRIVATE K4GAUDIPANDORA_USE_DDKALTEST)
   target_link_libraries(k4GaudiPandoraPlugins PRIVATE k4Reco::GaudiTrkUtils)
 endif()
 

--- a/k4GaudiPandora/CMakeLists.txt
+++ b/k4GaudiPandora/CMakeLists.txt
@@ -47,12 +47,17 @@ gaudi_add_module(k4GaudiPandoraPlugins
                       DD4hep::DDRec
                       DD4hep::DDCore
                       CLHEP::CLHEP
-                      k4Reco::GaudiTrkUtils
                       GSL::gsl
                       GSL::gslcblas # This seems to be necessary on Ubuntu 24.04 when linking with mold
                       ${PandoraSDK_LIBRARIES}
                       ${LCContent_LIBRARIES}
                     )
+if(K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS)
+  target_compile_definitions(k4GaudiPandoraPlugins PRIVATE K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS)
+else()
+  target_link_libraries(k4GaudiPandoraPlugins PRIVATE k4Reco::GaudiTrkUtils)
+endif()
+
 target_include_directories(k4GaudiPandoraPlugins PRIVATE include)
 target_include_directories(k4GaudiPandoraPlugins SYSTEM PUBLIC ${PandoraSDK_INCLUDE_DIRS} PRIVATE ${LCContent_INCLUDE_DIRS})
 

--- a/k4GaudiPandora/README.md
+++ b/k4GaudiPandora/README.md
@@ -20,24 +20,23 @@ limitations under the License.
 
 ### `K4GAUDIPANDORA_USE_DDKALTEST` (default `ON`)
 
-Controls whether tracks are extrapolated to the calorimeter face internally, with DDKalTest through
-`k4Reco::GaudiTrkUtils`.
+Selects where the track states at the calorimeter faces that pandora needs are computed.
 
-With the default `ON`, the legacy DDMarlinPandora behaviour is built: for tracks whose
+With the default `ON`, they are **recomputed here with DDKalTest**. For tracks whose
 `edm4hep::TrackState::AtCalorimeter` state is in the barrel,
-`DDTrackCreatorBase::GetTrackStatesAtCalo` re-propagates the track to the ECal endcap face and
-passes the result to pandora as an *additional* track state. LCContent's
-`TrackClusterAssociationAlgorithm` then tries both. This matters because a particle entering
-through the barrel can still shower in the endcap, so which face is the relevant one is not known
-until the cluster is (see
-[iLCSoft/DDMarlinPandora#12](https://github.com/iLCSoft/DDMarlinPandora/pull/12)). It requires
+`DDTrackCreatorBase::GetTrackStatesAtCalo` recomputes the extrapolation to the ECal endcap face and
+passes it to pandora as an *additional* track state, so that LCContent's
+`TrackClusterAssociationAlgorithm` can consider both. A particle entering through the barrel can
+still shower in the endcap, so which of the two faces is the relevant one is not known until the
+cluster is (see
+[iLCSoft/DDMarlinPandora#12](https://github.com/iLCSoft/DDMarlinPandora/pull/12)). This uses
 `k4Reco::GaudiTrkUtils`, and therefore LCIO, KalTest and DDKalTest.
 
-With `OFF`, only the track states already present in the input EDM are passed on, and
-`k4Reco::GaudiTrkUtils` — and with it LCIO — is no longer needed. This requires the extrapolation to
-the calorimeter to have been done upstream: `k4ActsTracking`'s `CKFTrackingAlg` does it with
-`ExtrapolateToCalo=True`. Note that only the states present on the track are used, so if the
-upstream extrapolation stores a single one, only that face is offered to pandora.
+With `OFF`, they are expected to have been **computed upstream**, as `k4ActsTracking`'s
+`CKFTrackingAlg` does with `ExtrapolateToCalo=True`. Nothing is recomputed here: the track states at
+the calorimeter found on the input tracks are forwarded as they are, so the number of faces offered
+to pandora is whatever the upstream extrapolation stored. `k4Reco::GaudiTrkUtils` — and with it
+LCIO — is not needed.
 
 Note that `OFF` does not make k4GaudiPandora depend on k4ActsTracking; nothing is linked or included
 from it.

--- a/k4GaudiPandora/README.md
+++ b/k4GaudiPandora/README.md
@@ -21,6 +21,8 @@ limitations under the License.
 ### `K4GAUDIPANDORA_USE_DDKALTEST` (default `ON`)
 
 Selects where the track states at the calorimeter faces that pandora needs are computed.
+The default `ON` preserves the legacy code behaviour. Setting this to `OFF` removes the
+transitive dependencies to LCIO, KalTest and DDKalTest.
 
 With the default `ON`, they are **recomputed here with DDKalTest**. For tracks whose
 `edm4hep::TrackState::AtCalorimeter` state is in the barrel,
@@ -30,13 +32,12 @@ passes it to pandora as an *additional* track state, so that LCContent's
 still shower in the endcap, so which of the two faces is the relevant one is not known until the
 cluster is (see
 [iLCSoft/DDMarlinPandora#12](https://github.com/iLCSoft/DDMarlinPandora/pull/12)). This uses
-`k4Reco::GaudiTrkUtils`, and therefore LCIO, KalTest and DDKalTest.
+`k4Reco::GaudiTrkUtils` (the source of the dependency on LCIO, KalTest and DDKalTest).
 
 With `OFF`, they are expected to have been **computed upstream**, as `k4ActsTracking`'s
-`CKFTrackingAlg` does with `ExtrapolateToCalo=True`. Nothing is recomputed here: *all*
+algorithms does with `ExtrapolateToCalo=True`. Nothing is recomputed here: *all*
 `AtCalorimeter` track states found on the input track are forwarded to pandora, so the number of
 faces it can choose between is whatever the upstream extrapolation stored.
-`k4Reco::GaudiTrkUtils` — and with it LCIO — is not needed.
 
 Note that `OFF` does not make k4GaudiPandora depend on k4ActsTracking; nothing is linked or included
 from it.
@@ -46,8 +47,7 @@ Caveats when `OFF`:
 - The input tracks **must** carry an `AtCalorimeter` track state. Tracks without one are dropped by
   the track creators, which report `Failed to extract a track`.
 - `TrackStateTolerance` has no effect, since it only bounds the acceptance radius of the endcap
-  state. `TrackSystemName` has no effect either — but note it is already inert in the `ON` build
-  too, as `GaudiDDKalTest` is used regardless of its value.
+  state.
 
 DDCaloDigi has been ported. The following changes have been done:
 - The function `getLayerConfig` has been included inside `initialize()` to avoid

--- a/k4GaudiPandora/README.md
+++ b/k4GaudiPandora/README.md
@@ -16,6 +16,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+## Build options
+
+### `K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS` (default `OFF`)
+
+Selects where the track state at the calorimeter face passed to pandora comes from.
+
+With the default `OFF`, the legacy pipeline is built: `DDTrackCreatorBase::GetTrackStatesAtCalo`
+re-propagates the track to the ECal endcap face with DDKalTest and passes the result to pandora as
+an *alternative* to the `edm4hep::TrackState::AtCalorimeter` state already stored in the EDM.
+LCContent's `TrackClusterAssociationAlgorithm` then tries both and keeps whichever finds a cluster.
+
+This exists because `GaudiTrkUtils::createTrackStateAtCaloFace`, which produced that stored state,
+does not navigate to the calorimeter: it propagates to the ECal barrel and to the ECal endcap and
+keeps whichever intersection is closest to the last tracker hit. That is not a first-intersection
+criterion and it picks the wrong face in the barrel/endcap transition region, which is what the
+alternative state hedges against (see
+[iLCSoft/DDMarlinPandora#12](https://github.com/iLCSoft/DDMarlinPandora/pull/12)). It requires
+`k4Reco::GaudiTrkUtils`, and therefore LCIO, KalTest and DDKalTest.
+
+With `ON`, the stored state is used as is and the DDKalTest re-propagation is not built, so
+`k4Reco::GaudiTrkUtils` — and with it LCIO — is no longer needed. This is correct when the input
+tracks come from `k4ActsTracking`'s `CKFTrackingAlg` with `ExtrapolateToCalo=True`, which obtains
+the state by propagating with an `Acts::Navigator` over the calorimeter face surfaces: the face is
+resolved by navigation rather than guessed, so the alternative state is redundant.
+
+Note that setting this does not make k4GaudiPandora depend on k4ActsTracking; it is a statement
+about the input data.
+
+Caveats when `ON`:
+
+- The input tracks **must** carry an `AtCalorimeter` track state. Tracks without one are dropped by
+  the track creators, which report `Failed to extract a track`.
+- `TrackStateTolerance` has no effect, since it only bounds the acceptance radius of the endcap
+  state. `TrackSystemName` has no effect either — but note it is already inert in the `OFF` build
+  too, as `GaudiDDKalTest` is used regardless of its value.
+
 DDCaloDigi has been ported. The following changes have been done:
 - The function `getLayerConfig` has been included inside `initialize()` to avoid
   having it run multiple times for every hit in the input. The member

--- a/k4GaudiPandora/README.md
+++ b/k4GaudiPandora/README.md
@@ -18,38 +18,36 @@ limitations under the License.
 -->
 ## Build options
 
-### `K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS` (default `OFF`)
+### `K4GAUDIPANDORA_USE_DDKALTEST` (default `ON`)
 
-Selects where the track state at the calorimeter face passed to pandora comes from.
+Controls whether tracks are extrapolated to the calorimeter face internally, with DDKalTest through
+`k4Reco::GaudiTrkUtils`.
 
-With the default `OFF`, the legacy pipeline is built: `DDTrackCreatorBase::GetTrackStatesAtCalo`
-re-propagates the track to the ECal endcap face with DDKalTest and passes the result to pandora as
-an *alternative* to the `edm4hep::TrackState::AtCalorimeter` state already stored in the EDM.
-LCContent's `TrackClusterAssociationAlgorithm` then tries both and keeps whichever finds a cluster.
-
-This exists because `GaudiTrkUtils::createTrackStateAtCaloFace`, which produced that stored state,
-does not navigate to the calorimeter: it propagates to the ECal barrel and to the ECal endcap and
-keeps whichever intersection is closest to the last tracker hit. That is not a first-intersection
-criterion and it picks the wrong face in the barrel/endcap transition region, which is what the
-alternative state hedges against (see
+With the default `ON`, the legacy DDMarlinPandora behaviour is built: for tracks whose
+`edm4hep::TrackState::AtCalorimeter` state is in the barrel,
+`DDTrackCreatorBase::GetTrackStatesAtCalo` re-propagates the track to the ECal endcap face and
+passes the result to pandora as an *additional* track state. LCContent's
+`TrackClusterAssociationAlgorithm` then tries both. This matters because a particle entering
+through the barrel can still shower in the endcap, so which face is the relevant one is not known
+until the cluster is (see
 [iLCSoft/DDMarlinPandora#12](https://github.com/iLCSoft/DDMarlinPandora/pull/12)). It requires
 `k4Reco::GaudiTrkUtils`, and therefore LCIO, KalTest and DDKalTest.
 
-With `ON`, the stored state is used as is and the DDKalTest re-propagation is not built, so
-`k4Reco::GaudiTrkUtils` — and with it LCIO — is no longer needed. This is correct when the input
-tracks come from `k4ActsTracking`'s `CKFTrackingAlg` with `ExtrapolateToCalo=True`, which obtains
-the state by propagating with an `Acts::Navigator` over the calorimeter face surfaces: the face is
-resolved by navigation rather than guessed, so the alternative state is redundant.
+With `OFF`, only the track states already present in the input EDM are passed on, and
+`k4Reco::GaudiTrkUtils` — and with it LCIO — is no longer needed. This requires the extrapolation to
+the calorimeter to have been done upstream: `k4ActsTracking`'s `CKFTrackingAlg` does it with
+`ExtrapolateToCalo=True`. Note that only the states present on the track are used, so if the
+upstream extrapolation stores a single one, only that face is offered to pandora.
 
-Note that setting this does not make k4GaudiPandora depend on k4ActsTracking; it is a statement
-about the input data.
+Note that `OFF` does not make k4GaudiPandora depend on k4ActsTracking; nothing is linked or included
+from it.
 
-Caveats when `ON`:
+Caveats when `OFF`:
 
 - The input tracks **must** carry an `AtCalorimeter` track state. Tracks without one are dropped by
   the track creators, which report `Failed to extract a track`.
 - `TrackStateTolerance` has no effect, since it only bounds the acceptance radius of the endcap
-  state. `TrackSystemName` has no effect either — but note it is already inert in the `OFF` build
+  state. `TrackSystemName` has no effect either — but note it is already inert in the `ON` build
   too, as `GaudiDDKalTest` is used regardless of its value.
 
 DDCaloDigi has been ported. The following changes have been done:

--- a/k4GaudiPandora/README.md
+++ b/k4GaudiPandora/README.md
@@ -33,10 +33,10 @@ cluster is (see
 `k4Reco::GaudiTrkUtils`, and therefore LCIO, KalTest and DDKalTest.
 
 With `OFF`, they are expected to have been **computed upstream**, as `k4ActsTracking`'s
-`CKFTrackingAlg` does with `ExtrapolateToCalo=True`. Nothing is recomputed here: the track states at
-the calorimeter found on the input tracks are forwarded as they are, so the number of faces offered
-to pandora is whatever the upstream extrapolation stored. `k4Reco::GaudiTrkUtils` — and with it
-LCIO — is not needed.
+`CKFTrackingAlg` does with `ExtrapolateToCalo=True`. Nothing is recomputed here: *all*
+`AtCalorimeter` track states found on the input track are forwarded to pandora, so the number of
+faces it can choose between is whatever the upstream extrapolation stored.
+`k4Reco::GaudiTrkUtils` — and with it LCIO — is not needed.
 
 Note that `OFF` does not make k4GaudiPandora depend on k4ActsTracking; nothing is linked or included
 from it.

--- a/k4GaudiPandora/include/DDTrackCreatorBase.h
+++ b/k4GaudiPandora/include/DDTrackCreatorBase.h
@@ -160,9 +160,9 @@ public:
   const TrackVector& GetTrackVector() const;
 
   /**
-   *  @brief  Pass the track state at the calorimeter of the input track to pandora, and, when
-   *          built with K4GAUDIPANDORA_USE_DDKALTEST, recompute a possible second track state
-   *          at the ECal Endcap
+   *  @brief  Pass the track states at the calorimeter of the input track to pandora. When built
+   *          with K4GAUDIPANDORA_USE_DDKALTEST only the first one is used, and a possible second
+   *          track state at the ECal Endcap is recomputed; otherwise all of them are passed on
    *
    *  @param track lcio track
    *  @param trackParameters pandora LCTrackParameters

--- a/k4GaudiPandora/include/DDTrackCreatorBase.h
+++ b/k4GaudiPandora/include/DDTrackCreatorBase.h
@@ -26,7 +26,7 @@
 #include <edm4hep/Track.h>
 #include <edm4hep/VertexCollection.h>
 
-#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+#ifdef K4GAUDIPANDORA_USE_DDKALTEST
 #include <k4Reco/GaudiDDKalTest.h>
 #include <k4Reco/GaudiDDKalTestTrack.h>
 #endif
@@ -160,9 +160,9 @@ public:
   const TrackVector& GetTrackVector() const;
 
   /**
-   *  @brief  Pass the track state at the calorimeter stored in the EDM to pandora, and, unless
-   *          K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS was defined at build time, calculate a
-   *          possible second track state at the ECal Endcap
+   *  @brief  Pass the track state at the calorimeter stored in the EDM to pandora, and, if
+   *          K4GAUDIPANDORA_USE_DDKALTEST was defined at build time, calculate a possible
+   *          second track state at the ECal Endcap
    *
    *  @param track lcio track
    *  @param trackParameters pandora LCTrackParameters
@@ -186,7 +186,7 @@ protected:
   TrackList m_daughterTrackList;          ///< The list of daughter tracks
   TrackToPidMap m_trackToPidMap;          ///< The map from track addresses to particle ids, where set by kinks/V0s
   float m_minimalTrackStateRadiusSquared; ///< minimal track state radius, derived value
-#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+#ifdef K4GAUDIPANDORA_USE_DDKALTEST
   std::shared_ptr<GaudiDDKalTest> m_trackingSystem = {}; ///< Tracking system used for track states
 #endif
   dd4hep::DDSegmentation::BitFieldCoder m_encoder = {};              ///< cell ID encoder

--- a/k4GaudiPandora/include/DDTrackCreatorBase.h
+++ b/k4GaudiPandora/include/DDTrackCreatorBase.h
@@ -160,9 +160,9 @@ public:
   const TrackVector& GetTrackVector() const;
 
   /**
-   *  @brief  Pass the track state at the calorimeter stored in the EDM to pandora, and, if
-   *          K4GAUDIPANDORA_USE_DDKALTEST was defined at build time, calculate a possible
-   *          second track state at the ECal Endcap
+   *  @brief  Pass the track state at the calorimeter of the input track to pandora, and, when
+   *          built with K4GAUDIPANDORA_USE_DDKALTEST, recompute a possible second track state
+   *          at the ECal Endcap
    *
    *  @param track lcio track
    *  @param trackParameters pandora LCTrackParameters

--- a/k4GaudiPandora/include/DDTrackCreatorBase.h
+++ b/k4GaudiPandora/include/DDTrackCreatorBase.h
@@ -26,8 +26,10 @@
 #include <edm4hep/Track.h>
 #include <edm4hep/VertexCollection.h>
 
+#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
 #include <k4Reco/GaudiDDKalTest.h>
 #include <k4Reco/GaudiDDKalTestTrack.h>
+#endif
 
 #include <memory>
 
@@ -158,7 +160,9 @@ public:
   const TrackVector& GetTrackVector() const;
 
   /**
-   *  @brief  Calculate possible second track state at the ECal Endcap
+   *  @brief  Pass the track state at the calorimeter stored in the EDM to pandora, and, unless
+   *          K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS was defined at build time, calculate a
+   *          possible second track state at the ECal Endcap
    *
    *  @param track lcio track
    *  @param trackParameters pandora LCTrackParameters
@@ -182,7 +186,9 @@ protected:
   TrackList m_daughterTrackList;          ///< The list of daughter tracks
   TrackToPidMap m_trackToPidMap;          ///< The map from track addresses to particle ids, where set by kinks/V0s
   float m_minimalTrackStateRadiusSquared; ///< minimal track state radius, derived value
-  std::shared_ptr<GaudiDDKalTest> m_trackingSystem = {};             ///< Tracking system used for track states
+#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+  std::shared_ptr<GaudiDDKalTest> m_trackingSystem = {}; ///< Tracking system used for track states
+#endif
   dd4hep::DDSegmentation::BitFieldCoder m_encoder = {};              ///< cell ID encoder
   std::shared_ptr<lc_content::LCTrackFactory> m_lcTrackFactory = {}; ///< LCTrackFactor for creating LCTracks
 

--- a/k4GaudiPandora/include/DDTrackCreatorBase.h
+++ b/k4GaudiPandora/include/DDTrackCreatorBase.h
@@ -160,7 +160,7 @@ public:
   const TrackVector& GetTrackVector() const;
 
   /**
-   *  @brief  Pass the track states at the calorimeter of the input track to pandora. When built
+   *  @brief  Pass the track state(s) at the calorimeter of the input track to pandora. When built
    *          with K4GAUDIPANDORA_USE_DDKALTEST only the first one is used, and a possible second
    *          track state at the ECal Endcap is recomputed; otherwise all of them are passed on
    *

--- a/k4GaudiPandora/src/DDTrackCreatorBase.cc
+++ b/k4GaudiPandora/src/DDTrackCreatorBase.cc
@@ -51,12 +51,14 @@ DDTrackCreatorBase::DDTrackCreatorBase(const Settings& settings, pandora::Pandor
   const float ecalInnerR = settings.m_eCalBarrelInnerR;
   const float tsTolerance = settings.m_trackStateTolerance;
   m_minimalTrackStateRadiusSquared = (ecalInnerR - tsTolerance) * (ecalInnerR - tsTolerance);
+#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
   // wrap in shared_ptr with a dummy destructor
   m_trackingSystem = std::make_shared<GaudiDDKalTest>(&m_algorithm);
   m_trackingSystem->init();
   //  FIXME: get info from metadata, collection, or service
   m_encoder = dd4hep::DDSegmentation::BitFieldCoder("subdet:5,side:-2,layer:9,module:8,sensor:8");
   m_trackingSystem->setEncoder(m_encoder);
+#endif
   m_lcTrackFactory = std::make_shared<lc_content::LCTrackFactory>();
 }
 
@@ -365,6 +367,12 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
     return;
   }
 
+#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+  // The track state stored in the EDM is the one DDKalTest picked between the ECal barrel and the
+  // ECal endcap intersections by keeping whichever was closest to the last tracker hit, which is
+  // not a first-intersection criterion and gets the face wrong in the barrel/endcap transition
+  // region. Re-propagate to the endcap face and pass that as an alternative, so that pandora can
+  // try both. Tracks from k4ActsTracking resolve the face by navigation and do not need this.
   GaudiDDKalTestTrack trk(&m_algorithm, m_trackingSystem.get());
   const auto& trkHits = track.getTrackerHits();
   std::vector<edm4hep::TrackerHit> trkHitsVec(trkHits.begin(), trkHits.end());
@@ -438,6 +446,7 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
     this->CopyTrackState(trackStateAtCaloEndcap, pandoraAtEndcap);
     trackParameters.m_trackStates.push_back(pandoraAtEndcap);
   }
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/k4GaudiPandora/src/DDTrackCreatorBase.cc
+++ b/k4GaudiPandora/src/DDTrackCreatorBase.cc
@@ -368,10 +368,10 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
   }
 
 #ifdef K4GAUDIPANDORA_USE_DDKALTEST
-  // The track state at the calorimeter stored in the EDM is the first face the track reaches, but
+  // The track state at the calorimeter on the input track is the first face the track reaches, but
   // a particle entering through the barrel can still shower in the endcap, and which face is the
-  // relevant one is not known until the cluster is. Re-propagate to the endcap face and pass that
-  // as an additional track state, leaving it to pandora to decide between them.
+  // relevant one is not known until the cluster is. Recompute the extrapolation to the endcap face
+  // with DDKalTest and pass it on as an additional track state, leaving the choice to pandora.
   GaudiDDKalTestTrack trk(&m_algorithm, m_trackingSystem.get());
   const auto& trkHits = track.getTrackerHits();
   std::vector<edm4hep::TrackerHit> trkHitsVec(trkHits.begin(), trkHits.end());

--- a/k4GaudiPandora/src/DDTrackCreatorBase.cc
+++ b/k4GaudiPandora/src/DDTrackCreatorBase.cc
@@ -51,7 +51,7 @@ DDTrackCreatorBase::DDTrackCreatorBase(const Settings& settings, pandora::Pandor
   const float ecalInnerR = settings.m_eCalBarrelInnerR;
   const float tsTolerance = settings.m_trackStateTolerance;
   m_minimalTrackStateRadiusSquared = (ecalInnerR - tsTolerance) * (ecalInnerR - tsTolerance);
-#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
+#ifdef K4GAUDIPANDORA_USE_DDKALTEST
   // wrap in shared_ptr with a dummy destructor
   m_trackingSystem = std::make_shared<GaudiDDKalTest>(&m_algorithm);
   m_trackingSystem->init();
@@ -367,12 +367,11 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
     return;
   }
 
-#ifndef K4GAUDIPANDORA_USE_K4ACTSTRACKING_TRACKS
-  // The track state stored in the EDM is the one DDKalTest picked between the ECal barrel and the
-  // ECal endcap intersections by keeping whichever was closest to the last tracker hit, which is
-  // not a first-intersection criterion and gets the face wrong in the barrel/endcap transition
-  // region. Re-propagate to the endcap face and pass that as an alternative, so that pandora can
-  // try both. Tracks from k4ActsTracking resolve the face by navigation and do not need this.
+#ifdef K4GAUDIPANDORA_USE_DDKALTEST
+  // The track state at the calorimeter stored in the EDM is the first face the track reaches, but
+  // a particle entering through the barrel can still shower in the endcap, and which face is the
+  // relevant one is not known until the cluster is. Re-propagate to the endcap face and pass that
+  // as an additional track state, leaving it to pandora to decide between them.
   GaudiDDKalTestTrack trk(&m_algorithm, m_trackingSystem.get());
   const auto& trkHits = track.getTrackerHits();
   std::vector<edm4hep::TrackerHit> trkHitsVec(trkHits.begin(), trkHits.end());

--- a/k4GaudiPandora/src/DDTrackCreatorBase.cc
+++ b/k4GaudiPandora/src/DDTrackCreatorBase.cc
@@ -336,21 +336,30 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
     return;
   }
 
-  size_t i = static_cast<size_t>(-1);
-  for (size_t j = 0; j < track.getTrackStates().size(); ++j) {
-    if (track.getTrackStates()[j].location == edm4hep::TrackState::AtCalorimeter) {
-      i = j;
-      break;
+  std::vector<edm4hep::TrackState> statesAtCalo;
+  for (const auto& ts : track.getTrackStates()) {
+    if (ts.location == edm4hep::TrackState::AtCalorimeter) {
+      statesAtCalo.push_back(ts);
     }
   }
 
-  if (i == static_cast<size_t>(-1)) {
+  if (statesAtCalo.empty()) {
     m_algorithm.verbose() << "Track does not have a trackState at calorimeter" << endmsg;
     // streamlog_out(DEBUG3) << toString(track) << endmsg;
     return;
   }
 
-  const auto& trackAtCalo = track.getTrackStates(i);
+#ifndef K4GAUDIPANDORA_USE_DDKALTEST
+  // The extrapolations were done upstream, so every track state at the calorimeter that the input
+  // track carries is passed on and pandora is left to choose between them.
+  m_algorithm.verbose() << "Passing on " << statesAtCalo.size() << " track state(s) at the calorimeter" << endmsg;
+  for (const auto& stateAtCalo : statesAtCalo) {
+    pandora::InputTrackState pandoraTrackState;
+    this->CopyTrackState(stateAtCalo, pandoraTrackState);
+    trackParameters.m_trackStates.push_back(pandoraTrackState);
+  }
+#else
+  const auto& trackAtCalo = statesAtCalo.front();
 
   const auto& tsPosition = trackAtCalo.referencePoint;
 
@@ -367,7 +376,6 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo(edm4hep::Track const& track,
     return;
   }
 
-#ifdef K4GAUDIPANDORA_USE_DDKALTEST
   // The track state at the calorimeter on the input track is the first face the track reaches, but
   // a particle entering through the barrel can still shower in the endcap, and which face is the
   // relevant one is not known until the cluster is. Recompute the extrapolation to the endcap face


### PR DESCRIPTION
BEGINRELEASENOTES
- Added the flag `K4GAUDIPANDORA_USE_DDKALTEST` to compile with the DDKalTest-based recomputation of the track states at the calorimeter faces, instead of using a direct unpacking of what is provided from upstream. **The default is `ON`, so that the legacy behaviour is preserved.**

ENDRELEASENOTES

This PR is the last bit from allowing a functional build of the software stack without LCIO and the related legacy packages.
Example of the build of a such a stack: https://github.com/MuonColliderSoft/mucoll-spack/actions/runs/31485685470

Consuming this in spack requires a new variant to be introduced to steer the cmake flag