### PR TITLE
Fix: missing DDPandoraPFANewAlgorithm::reset() leaks tracks into the next event

### DIFF
--- a/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
+++ b/k4GaudiPandora/src/DDPandoraPFANewAlgorithm.cpp
@@ -173,6 +173,15 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& lhCalCollections,
                                      const std::vector<const edm4hep::CaloHitSimCaloHitLinkCollection*>&) const {
   try {
+    // Clear the track creator's per-event bookkeeping when this event goes out
+    // of scope, on the normal and the exception paths alike. It has to happen
+    // here rather than at the top of the next event: m_trackVector holds
+    // edm4hep::Track handles into the input collections, which are only alive
+    // for the duration of this call.
+    struct ResetGuard {
+      const DDPandoraPFANewAlgorithm* self;
+      ~ResetGuard() { self->reset(); }
+    } resetGuard{this};
 
     std::vector<edm4hep::MCParticle> mcParticlesVector;
     for (const auto& mcParticleCollection : MCParticleCollections) {
@@ -255,7 +264,6 @@ DDPandoraPFANewAlgorithm::operator()(const std::vector<const edm4hep::MCParticle
                             m_pfoCreator->CreateParticleFlowObjects(
                                 pClusterCollection, pReconstructedParticleCollection, pStartVertexCollection))
     PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Reset(m_pPandora))
-    // Reset();
 
     return std::make_tuple(std::move(pClusterCollection), std::move(pReconstructedParticleCollection),
                            std::move(pStartVertexCollection));


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix bug in missing call of DDPandoraPFANewAlgorithm::reset(). The local vectors are now reset again

ENDRELEASENOTES

DDPandoraPFANewAlgorithm::reset() was never called (its call site was commented out), so the track creator's per-event state accumulated for the whole job, e.g. m_trackVector grew 3525 → 42013 over 10 events. 

The lists that are actually read per event are only filled from kink/V0 vertex collections that are not supplied in all configs (none in MuColl), but enabling those would leak stale PIDs and V0 flags across events, since TrackID = (collectionID << 32) | index repeats every event. 
Fixed with an RAII guard so the reset also runs on exception paths and while the input collections the handles point into are still alive; verified bit-identical PFOs on 10 events with full BIB overlay in MAIA.